### PR TITLE
Fix persist header case and Settings namespace

### DIFF
--- a/Calculadora/app.cpp
+++ b/Calculadora/app.cpp
@@ -13,7 +13,7 @@
 
 // Bibliotecas Personalizadas
 #include "Debug.h"
-#include "Persist.h"   // JSON + CSV (MaterialDTO, save/load, Settings)
+#include "persist.h"   // JSON + CSV (MaterialDTO, save/load, Settings)
 #include "modulos.h"   // Material, Corte, App, Como
 
 // ------------------------------------------------------------
@@ -78,7 +78,7 @@ void App::iniciar() {
     // ===========================
     // 0) Carregar settings
     // ===========================
-    Persist::Settings settings = Persist::loadOrCreateSettings(); // data/settings.json
+    Settings settings = Persist::loadOrCreateSettings(); // data/settings.json
 
     // Configuração de casas decimais (limitamos 0..6 por segurança)
     dec = std::clamp(settings.decimal_places, 0, 6);


### PR DESCRIPTION
## Summary
- fix include of `persist.h` to match filesystem case
- use global `Settings` type instead of nonexistent `Persist::Settings`

## Testing
- `g++ -std=c++17 main.cpp app.cpp -o app -Ithird_party`

------
https://chatgpt.com/codex/tasks/task_e_68a1de0e79188327bafc9dbcefe8255a