### PR TITLE
Add generic log templates and remove manual string conversions

### DIFF
--- a/Calculadora/Debug.h
+++ b/Calculadora/Debug.h
@@ -12,6 +12,7 @@
 #include <iostream>     // Entrada e saída (ex: cout)
 #include <string>       // Manipulação de texto
 #include <map>          // Mapa ordenado chave-valor
+#include <sstream>      // Conversão genérica para string
 
 namespace wr {
 
@@ -28,10 +29,7 @@ namespace wr {
     };
 
     inline void p(const std::string& mensagem) {
-
-        // Caso a mensagem for um numero
-        
-        // printa no terminal a mensagem
+        // Imprime mensagem simples
         std::cout << "[DEBUG] " << mensagem << colorMap.at("Reset") << "\n";
     }
 
@@ -44,6 +42,27 @@ namespace wr {
         std::string corANSI = (it != colorMap.end()) ? it->second : colorMap.at("White");
 
         std::cout << corANSI << "[" << modulo << "]" << colorMap.at("Reset") << " " << mensagem << "\n";
+    }
+
+    template <typename T>
+    inline void p(const T& valor) {
+        std::ostringstream oss;
+        oss << valor;
+        p(oss.str());
+    }
+
+    template <typename T>
+    inline void p(const std::string& modulo, const T& valor) {
+        std::ostringstream oss;
+        oss << valor;
+        p(modulo, oss.str());
+    }
+
+    template <typename T>
+    inline void p(const std::string& modulo, const T& valor, const std::string& cor) {
+        std::ostringstream oss;
+        oss << valor;
+        p(modulo, oss.str(), cor);
     }
 
 }

--- a/Calculadora/app.cpp
+++ b/Calculadora/app.cpp
@@ -10,6 +10,7 @@
 #include <limits>
 #include <vector>
 #include <algorithm> // std::clamp
+#include <sstream>
 
 // Bibliotecas Personalizadas
 #include "Debug.h"
@@ -123,7 +124,9 @@ void App::iniciar() {
             wr::p("DATA", "Falha ao criar materiais.json", "Red");
         }
     } else {
-        wr::p("DATA", "materiais.json carregado (versao " + std::to_string(version) + ")", "Green");
+        std::ostringstream oss;
+        oss << "materiais.json carregado (versao " << version << ")";
+        wr::p("DATA", oss.str(), "Green");
     }
 
     // ===========================


### PR DESCRIPTION
## Summary
- Support streaming any type in debug logs by adding templated `p` overloads
- Remove `std::to_string` usage when logging version and build message with `ostringstream`

## Testing
- `g++ -std=c++17 main.cpp app.cpp -o calc_app && ./calc_app <<EOF
n
n
n
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68a1e2fe3dc483278f5a33cbad5a8d8f