### PR TITLE
feat: add materials menu to manage base

### DIFF
--- a/Calculadora/modulos.h
+++ b/Calculadora/modulos.h
@@ -116,6 +116,7 @@ private:
 
     void importarCSV();
     bool carregarJSON();
+    void menuMateriais();
     void escolherPreco();
     void calcularCorte();
     void exportar();


### PR DESCRIPTION
## Summary
- add menuMateriais to list/add/edit/remove materials
- persist JSON after material changes and rebuild material objects
- call menu before price selection

## Testing
- `g++ Calculadora/*.cpp -std=c++17 -ICalculadora -o calcapp`
- `./calcapp <<'EOF'
 n
 0
 1
 n
 EOF`


------
https://chatgpt.com/codex/tasks/task_e_68a1e9f13c648327ac497498d1eca917