### PR TITLE
Add CSV export for cuts to CSV

### DIFF
--- a/Calculadora/modulos.h
+++ b/Calculadora/modulos.h
@@ -88,6 +88,13 @@ public:
         valor = area * porm2;
     }
 
+    // Getters
+    const std::string& capNome() const noexcept { return nome; }
+    double capLarg() const noexcept { return largura; }
+    double capComp() const noexcept { return comprimento; }
+    double capArea() const noexcept { return area; }
+    double capValor() const noexcept { return valor; }
+
     void imprimir() const {
         std::cout << "\nCorte: " << nome << "\n"
                   << "Valor por m2 : " << UN_MONE << porm2 << "\n"
@@ -113,11 +120,12 @@ private:
     Settings settings;
     std::vector<MaterialDTO> base;
     std::vector<Material> mats;
+    std::vector<Corte> cortes;
 
     void importarCSV();
     bool carregarJSON();
     void escolherPreco();
-    void calcularCorte();
+    void solicitarCortes();
     void exportar();
 
 public:

--- a/Calculadora/persist.h
+++ b/Calculadora/persist.h
@@ -12,6 +12,9 @@
 #include <exception>
 #include "Debug.h"
 
+// Forward declaration de Corte (definido em modulos.h)
+class Corte;
+
 namespace fs = std::filesystem;
 
 // ---- DTO de Material (somente dados base) ----
@@ -213,6 +216,9 @@ inline bool saveCSV(const std::string& path, const std::vector<MaterialDTO>& ite
     }
     return atomicWrite(fs::path(dataPath(path)), oss.str());
 }
+
+// -------------------- CSV de Cortes --------------------
+bool saveCutsCSV(const std::string& path, const std::vector<Corte>& cortes);
 
 // -------------------- CSV: Leitura --------------------
 inline bool loadCSV(const std::string& path, std::vector<MaterialDTO>& out) {

--- a/Calculadora/persist_cuts.cpp
+++ b/Calculadora/persist_cuts.cpp
@@ -1,0 +1,27 @@
+#include "persist.h"
+#include "modulos.h"
+
+namespace Persist {
+
+bool saveCutsCSV(const std::string& path, const std::vector<Corte>& cortes) {
+    std::ostringstream oss;
+    oss << "nome;largura;comprimento;area;subtotal\n";
+
+    double total = 0.0;
+    for (const auto& c : cortes) {
+        std::string safe = c.capNome();
+        for (auto& ch : safe) if (ch == ';') ch = ',';
+
+        oss << safe << ';'
+            << to_str_br(c.capLarg()) << ';'
+            << to_str_br(c.capComp()) << ';'
+            << to_str_br(c.capArea()) << ';'
+            << to_str_br(c.capValor()) << "\n";
+        total += c.capValor();
+    }
+
+    oss << "TOTAL;" << to_str_br(total) << "\n";
+    return atomicWrite(fs::path(dataPath(path)), oss.str());
+}
+
+} // namespace Persist


### PR DESCRIPTION
## Summary
- add `Persist::saveCutsCSV` to export cuts with totals
- expose Corte getters and collect cuts via `solicitarCortes`
- prompt user to save cuts to date-stamped CSV file

## Testing
- `g++ -std=c++17 Calculadora/main.cpp Calculadora/app.cpp Calculadora/persist_cuts.cpp -o calculadora`
- `./calculadora` (manual interaction)


------
https://chatgpt.com/codex/tasks/task_e_68a1eab1c8188327b78334a60fd65d30