### PR TITLE
[persist] feat: salvar plano em JSON/CSV

### DIFF
--- a/Calculadora/include/persist.hpp
+++ b/Calculadora/include/persist.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include "plano_corte.h"
 
 namespace Persist {
 
@@ -26,6 +27,23 @@ std::string makeId(const std::string& projeto);
 //   std::string dir = Persist::outPlanosDirFor("Meu Projeto", id);
 // ----------------------------------------------------------------------
 std::string outPlanosDirFor(const std::string& projeto, const std::string& id);
+
+// ----------------------------------------------------------------------
+// Salva um PlanoCorteDTO em JSON no arquivo "plano.json" dentro de `dir`.
+// Utiliza escrita atômica para evitar corrupção em caso de falha.
+// Exemplo:
+//   Persist::savePlanoJSON("out/planos/xyz", plano);
+// ----------------------------------------------------------------------
+bool savePlanoJSON(const std::string& dir, const PlanoCorteDTO& plano);
+
+// ----------------------------------------------------------------------
+// Salva um PlanoCorteDTO em CSV no arquivo "plano.csv" dentro de `dir`.
+// Cabeçalho: "nome;largura_m;comprimento_m;porm2;area_m2;valor;rot90".
+// Números são formatados com vírgula decimal.
+// Exemplo:
+//   Persist::savePlanoCSV("out/planos/xyz", plano);
+// ----------------------------------------------------------------------
+bool savePlanoCSV(const std::string& dir, const PlanoCorteDTO& plano);
 
 } // namespace Persist
 

--- a/Calculadora/tests/plano_persist_test.cpp
+++ b/Calculadora/tests/plano_persist_test.cpp
@@ -1,0 +1,46 @@
+#include "persist.hpp"
+#include "plano_corte.h"
+#include <nlohmann/json.hpp>
+#include <cassert>
+#include <fstream>
+#include <filesystem>
+
+// Testa salvamento e leitura imediata de plano em JSON e CSV
+void test_plano_persist_io() {
+    // monta um corte simples
+    CorteDTO c{"Lateral", 2.0, 0.15, 180.0, 0.3, 54.0, false};
+
+    // monta plano com o corte
+    PlanoCorteDTO p;
+    p.id = "plano_teste";
+    p.projeto = "ProjetoX";
+    p.gerado_em = "2025-08-17T18:30:12";
+    p.algoritmo = "simples";
+    p.porm2_usado = 180.0;
+    p.cortes.push_back(c);
+    p.total_area_m2 = 0.3;
+    p.total_valor = 54.0;
+
+    const std::string dir = Persist::outPlanosDirFor(p.projeto, p.id);
+
+    // salva e lê JSON
+    assert(Persist::savePlanoJSON(dir, p));
+    std::ifstream jf(dir + "/plano.json");
+    assert(jf);
+    nlohmann::json j; jf >> j;
+    PlanoCorteDTO p2 = j.get<PlanoCorteDTO>();
+    assert(p2.cortes.size() == 1);
+    assert(p2.cortes[0].nome == "Lateral");
+
+    // salva e lê CSV
+    assert(Persist::savePlanoCSV(dir, p));
+    std::ifstream cf(dir + "/plano.csv");
+    assert(cf);
+    std::string header; std::getline(cf, header);
+    assert(header == "nome;largura_m;comprimento_m;porm2;area_m2;valor;rot90");
+    std::string line; std::getline(cf, line);
+    assert(line.find(".") == std::string::npos); // números com vírgula
+    assert(line.find("Lateral") == 0);
+
+    std::filesystem::remove_all(dir);
+}

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -8,6 +8,7 @@ void test_extremos();
 void test_corte();
 void test_plano_dto();
 void test_persist_helpers();
+void test_plano_persist_io();
 
 // Executa todos os testes
 int main() {
@@ -18,6 +19,7 @@ int main() {
     test_corte();
     test_plano_dto();
     test_persist_helpers();
+    test_plano_persist_io();
     return 0;
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -11,6 +11,7 @@ Esta calculadora evoluirá em etapas para oferecer mais flexibilidade e confiabi
   - Centralizar leitura/escrita em formatos adicionais (ex.: XML).
   - Integrar validação de dados antes de salvar. ✅
   - Suporte a serialização de planos de corte (CorteDTO e PlanoCorteDTO). ✅
+  - Funções para salvar PlanoCorteDTO em JSON e CSV. ✅
 - **Interface de linha de comando** (`Calculadora/main.cpp`)
   - Adicionar opções de ajuda e parâmetros para cálculos automatizados. ✅
   - Melhorar mensagens de erro para entradas inválidas.


### PR DESCRIPTION
## Summary
- add `savePlanoJSON` using atomic writes to persist `PlanoCorteDTO`
- export cutting plans to CSV with Brazilian number format
- test immediate readback for JSON/CSV plan exports

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app`
- `make -C tests`
- `./tests/run_tests`

### Checklist
- Revisão de código: ✅
- Testes adicionados e rodando: ✅
- Documentação atualizada: ✅
- Build e lint: ✅
- Commits padronizados: ✅

------
https://chatgpt.com/codex/tasks/task_e_68a25514343c83279499bb93ea34b674