### PR TITLE
[cli] feat: add projeto flag and command stubs

### DIFF
--- a/Calculadora/include/cli.h
+++ b/Calculadora/include/cli.h
@@ -3,9 +3,21 @@
 // ----------------------------------------------------------
 // Estruturas e funções para argumentos de linha de comando
 // ----------------------------------------------------------
+#include <string>
+
+// Comandos reconhecidos pela aplicação (ainda não implementados)
+enum class Comando {
+    Nenhum,   // nenhum comando informado
+    Abrir,    // abrir projeto existente
+    Listar,   // listar recursos
+    Comparar  // comparar dados
+};
+
 struct CliOptions {
     bool showHelp = false; // exibir ajuda
     bool autoMode = false; // modo automático
+    std::string projeto;   // caminho para o projeto
+    Comando comando = Comando::Nenhum; // comando solicitado
 };
 
 // Processa argc/argv e devolve opções reconhecidas

--- a/Calculadora/src/cli.cpp
+++ b/Calculadora/src/cli.cpp
@@ -14,6 +14,18 @@ CliOptions parseArgs(int argc, char* argv[]) {
             opt.showHelp = true;
         } else if (a == "--auto") {
             opt.autoMode = true;
+        } else if (a == "--projeto" && i + 1 < argc) {
+            // consome próximo argumento como caminho do projeto
+            opt.projeto = argv[++i];
+        } else if (opt.comando == Comando::Nenhum) {
+            // registra comando principal
+            if (a == "abrir") {
+                opt.comando = Comando::Abrir;
+            } else if (a == "listar") {
+                opt.comando = Comando::Listar;
+            } else if (a == "comparar") {
+                opt.comando = Comando::Comparar;
+            }
         }
     }
     return opt;

--- a/Calculadora/src/main.cpp
+++ b/Calculadora/src/main.cpp
@@ -6,6 +6,7 @@
 #include "Debug.h"
 #include "App.h"
 #include "cli.h"
+#include <string>
 
 // ----------------------------------------------------------
 // Entrada principal da aplicação
@@ -21,10 +22,29 @@ int main(int argc, char* argv[]) {
 
     // Se for solicitado help, exibe instruções e sai
     if (opt.showHelp) {
-        std::cout << "Uso: ./app [--auto] [--help]\n";
+        std::cout << "Uso: ./app [comando] [opcoes]\n";
+        std::cout << "  comandos: abrir, listar, comparar (em construcao)\n";
         std::cout << "  --auto : calcula usando o material mais barato.\n";
+        std::cout << "  --projeto <arq> : abre projeto informado.\n";
         std::cout << "  --help : mostra esta ajuda e finaliza.\n";
         return 0;
+    }
+
+    // Se houver comando, apenas registra placeholder
+    if (opt.comando != Comando::Nenhum) {
+        std::string nome;
+        switch (opt.comando) {
+            case Comando::Abrir: nome = "abrir"; break;
+            case Comando::Listar: nome = "listar"; break;
+            case Comando::Comparar: nome = "comparar"; break;
+            default: nome = ""; break;
+        }
+        wr::p("MAIN", "Comando '" + nome + "' ainda nao implementado.", "Yellow");
+        return 0;
+    }
+
+    if (!opt.projeto.empty()) {
+        wr::p("MAIN", "Projeto informado: " + opt.projeto, "Blue");
     }
 
     wr::p("MAIN", "Iniciando..", "Green");

--- a/Calculadora/tests/cli_test.cpp
+++ b/Calculadora/tests/cli_test.cpp
@@ -14,4 +14,22 @@ void test_cli() {
     CliOptions o2 = parseArgs(2, const_cast<char**>(a2));
     assert(o2.autoMode);
     assert(!o2.showHelp);
+
+    // testa --projeto com caminho
+    const char* a3[] = {"app", "--projeto", "proj.json"};
+    CliOptions o3 = parseArgs(3, const_cast<char**>(a3));
+    assert(o3.projeto == "proj.json");
+
+    // testa comandos
+    const char* a4[] = {"app", "abrir"};
+    CliOptions o4 = parseArgs(2, const_cast<char**>(a4));
+    assert(o4.comando == Comando::Abrir);
+
+    const char* a5[] = {"app", "listar"};
+    CliOptions o5 = parseArgs(2, const_cast<char**>(a5));
+    assert(o5.comando == Comando::Listar);
+
+    const char* a6[] = {"app", "comparar"};
+    CliOptions o6 = parseArgs(2, const_cast<char**>(a6));
+    assert(o6.comando == Comando::Comparar);
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -17,6 +17,7 @@ Esta calculadora evoluirá em etapas para oferecer mais flexibilidade e confiabi
 - **Interface de linha de comando** (`Calculadora/main.cpp`)
   - Adicionar opções de ajuda e parâmetros para cálculos automatizados. ✅
   - Melhorar mensagens de erro para entradas inválidas.
+  - Suporte inicial a `--projeto` e registro dos comandos `abrir`, `listar` e `comparar`. ✅
 - **Testes automatizados** (novo diretório `tests/`)
   - Criar casos de teste unitários para validar comparações e rotinas de persistência.
   - Integrar com execução contínua (CI) para evitar regressões.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -12,6 +12,11 @@ Exibe instruções de uso e encerra.
 ```
 Inicia em modo automático, escolhendo o material mais barato.
 
+```bash
+./app --projeto caminho/do/projeto.json
+```
+Carrega o projeto informado para uso na sessão (em desenvolvimento).
+
 As opções podem ser combinadas conforme necessário.
 
 ## Configuração do VS Code


### PR DESCRIPTION
## Summary
- parse `--projeto` flag and register future commands
- basic help output and logging for commands
- docs updated for new flag

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app`
- `make -C tests`
- `./tests/run_tests`

## Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a25c5f155883278a8d2c4b00753242