### PR TITLE
[persist] feat: log creation events and document meter units

### DIFF
--- a/Calculadora/tests/data_path_test.cpp
+++ b/Calculadora/tests/data_path_test.cpp
@@ -1,0 +1,10 @@
+#include <cassert>
+#include <filesystem>
+#include "persist.h"
+
+// Testa que dataPath cria o diretório `data` e retorna o caminho correto
+void test_data_path() {
+    const std::string p = Persist::dataPath("dummy.txt");
+    assert(p == "data/dummy.txt");
+    assert(std::filesystem::exists("data"));
+}

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -10,6 +10,7 @@ void test_plano_dto();
 void test_persist_helpers();
 void test_plano_io();
 void test_plano_index();
+void test_data_path();
 
 // Executa todos os testes
 int main() {
@@ -22,5 +23,6 @@ int main() {
     test_persist_helpers();
     test_plano_io();
     test_plano_index();
+    test_data_path();
     return 0;
 }


### PR DESCRIPTION
## Summary
- documenta que larguras e comprimentos permanecem em metros
- registra com `wr::p` a criação de arquivos e diretórios
- destaca falhas de I/O em vermelho e avisos em amarelo

## Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a265aaf8848327a18f3ebbb55bb9eb