### PR TITLE
[persist] feat: add JSON plan loading

### DIFF
--- a/Calculadora/include/persist.hpp
+++ b/Calculadora/include/persist.hpp
@@ -46,6 +46,14 @@ bool savePlanoJSON(const std::string& dir, const PlanoCorteDTO& plano);
 bool savePlanoCSV(const std::string& dir, const PlanoCorteDTO& plano);
 
 // ----------------------------------------------------------------------
+// Reabre um PlanoCorteDTO a partir de um arquivo JSON previamente salvo.
+// Retorna verdadeiro em caso de sucesso.
+// Exemplo:
+//   PlanoCorteDTO p; Persist::loadPlanoJSON("out/planos/xyz/plano.json", p);
+// ----------------------------------------------------------------------
+bool loadPlanoJSON(const std::string& file, PlanoCorteDTO& out);
+
+// ----------------------------------------------------------------------
 // Atualiza o arquivo de índice global "out/planos/index.json".
 // Se já existir entrada com mesmo `id`, ela é substituída.
 // Cria o arquivo caso não exista, usando escrita atômica.

--- a/Calculadora/src/persist.cpp
+++ b/Calculadora/src/persist.cpp
@@ -101,6 +101,27 @@ bool savePlanoCSV(const std::string& dir, const PlanoCorteDTO& plano) {
     }
 }
 
+// Lê o JSON indicado e preenche `out` com os dados do plano
+bool loadPlanoJSON(const std::string& file, PlanoCorteDTO& out) {
+    const fs::path p = file;
+    try {
+        std::ifstream f(p);
+        if (!f) {
+            wr::p("PERSIST", p.string() + " open fail", "Red");
+            return false;
+        }
+        json j; f >> j;
+        out = j.get<PlanoCorteDTO>();
+        return true;
+    } catch (const std::exception& e) {
+        wr::p("PERSIST", p.string() + " exception: " + e.what(), "Red");
+        return false;
+    } catch (...) {
+        wr::p("PERSIST", p.string() + " unknown exception", "Red");
+        return false;
+    }
+}
+
 bool updateIndex(const PlanoCorteDTO& plano) {
     const fs::path indexPath = fs::path("out") / "planos" / "index.json";
     try {

--- a/Calculadora/tests/plano_io_test.cpp
+++ b/Calculadora/tests/plano_io_test.cpp
@@ -1,7 +1,6 @@
 #include "persist.hpp"
 #include "plano_corte.h"
 #include "Corte.h"
-#include <nlohmann/json.hpp>
 #include <cassert>
 #include <fstream>
 #include <filesystem>
@@ -30,10 +29,8 @@ void test_plano_io() {
 
     // salva e lê JSON
     assert(Persist::savePlanoJSON(dir, p));
-    std::ifstream jf(dir + "/plano.json");
-    assert(jf);
-    nlohmann::json j; jf >> j;
-    PlanoCorteDTO p2 = j.get<PlanoCorteDTO>();
+    PlanoCorteDTO p2;
+    assert(Persist::loadPlanoJSON(dir + "/plano.json", p2));
     assert(p2.cortes.size() == 1);
     assert(p2.cortes[0].nome == "Lateral");
     assert(p2.total_valor == p.total_valor);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,6 +12,7 @@ Esta calculadora evoluirá em etapas para oferecer mais flexibilidade e confiabi
   - Integrar validação de dados antes de salvar. ✅
   - Suporte a serialização de planos de corte (CorteDTO e PlanoCorteDTO). ✅
   - Funções para salvar PlanoCorteDTO em JSON e CSV. ✅
+  - Função para carregar PlanoCorteDTO em JSON (`loadPlanoJSON`). ✅
   - Índice global de planos com atualização atômica (`updateIndex`). ✅
   - Persistência automática de planos gerados com `makeId`, `outPlanosDirFor`, `savePlanoJSON/CSV` e `updateIndex`. ✅
 - **Interface de linha de comando** (`Calculadora/main.cpp`)
@@ -29,6 +30,7 @@ Com a evolução recente, a camada de persistência agora:
 - Serializa planos de corte em JSON e CSV.
 - Atualiza o índice global de forma atômica por meio de `updateIndex`.
 - Salva automaticamente os planos gerados utilizando `makeId`, `outPlanosDirFor`, `savePlanoJSON/CSV` e `updateIndex`.
+- Permite reabrir planos salvos com `loadPlanoJSON`.
 
 ## Melhorias propostas
 


### PR DESCRIPTION
## Summary
- add helper to load saved cut plans from JSON
- exercise JSON loading in plan I/O tests
- document new ability in roadmap

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app`
- `make -C tests`
- `./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_68a283ebb4188327a4f10aecb7676338