### PR TITLE
[persist] feat: adicionar tipo e schema_version aos materiais

### DIFF
--- a/Calculadora/UPDATE.md
+++ b/Calculadora/UPDATE.md
@@ -345,7 +345,7 @@ Menu Principal
 
 ## 9) Roadmap Sugerido
 **Curto prazo (v0.02)**
-- [ ] Adicionar `tipo` a `MaterialDTO` + migração on‑load.
+ - [x] Adicionar `tipo` a `MaterialDTO` + migração on‑load.
 - [ ] Implementar classes `Unitario/Linear/Cubico` + factory.
 - [ ] Ajustar CLI para cadastro/listagem por tipo.
 - [ ] Implementar menu principal com navegação básica.

--- a/Calculadora/data/materiais.json
+++ b/Calculadora/data/materiais.json
@@ -1,35 +1,40 @@
 {
+  "schema_version": 1,
   "materiais": [
     {
-      "comprimento": 3.0,
-      "largura": 0.2,
       "nome": "Pinus 20cm",
-      "valor": 17.28
+      "tipo": "linear",
+      "valor": 17.28,
+      "largura": 0.2,
+      "comprimento": 3.0
     },
     {
-      "comprimento": 2.75,
-      "largura": 1.85,
       "nome": "MDF 15mm",
-      "valor": 179.9
+      "tipo": "linear",
+      "valor": 179.9,
+      "largura": 1.85,
+      "comprimento": 2.75
     },
     {
-      "comprimento": 3.0,
-      "largura": 0.3,
       "nome": "Pinus 30cm",
-      "valor": 33.75
+      "tipo": "linear",
+      "valor": 33.75,
+      "largura": 0.3,
+      "comprimento": 3.0
     },
     {
-      "comprimento": 2.75,
-      "largura": 1.85,
       "nome": "MDF 3mm",
-      "valor": 60.0
+      "tipo": "linear",
+      "valor": 60.0,
+      "largura": 1.85,
+      "comprimento": 2.75
     },
     {
-      "comprimento": 2.75,
-      "largura": 1.85,
       "nome": "MDF 9mm",
-      "valor": 140.0
+      "tipo": "linear",
+      "valor": 140.0,
+      "largura": 1.85,
+      "comprimento": 2.75
     }
-  ],
-  "version": 1
+  ]
 }

--- a/Calculadora/data/materiais.json.bak
+++ b/Calculadora/data/materiais.json.bak
@@ -1,29 +1,40 @@
 {
+  "schema_version": 1,
   "materiais": [
     {
-      "comprimento": 3.0,
-      "largura": 0.2,
       "nome": "Pinus 20cm",
-      "valor": 17.28
+      "tipo": "linear",
+      "valor": 17.28,
+      "largura": 0.2,
+      "comprimento": 3.0
     },
     {
-      "comprimento": 2.75,
-      "largura": 1.85,
       "nome": "MDF 15mm",
-      "valor": 179.9
-    },
-    {
-      "comprimento": 3.0,
-      "largura": 0.3,
-      "nome": "Pinus 30cm",
-      "valor": 33.75
-    },
-    {
-      "comprimento": 2.75,
+      "tipo": "linear",
+      "valor": 179.9,
       "largura": 1.85,
+      "comprimento": 2.75
+    },
+    {
+      "nome": "Pinus 30cm",
+      "tipo": "linear",
+      "valor": 33.75,
+      "largura": 0.3,
+      "comprimento": 3.0
+    },
+    {
       "nome": "MDF 3mm",
-      "valor": 60.0
+      "tipo": "linear",
+      "valor": 60.0,
+      "largura": 1.85,
+      "comprimento": 2.75
+    },
+    {
+      "nome": "MDF 9mm",
+      "tipo": "linear",
+      "valor": 140.0,
+      "largura": 1.85,
+      "comprimento": 2.75
     }
-  ],
-  "version": 1
+  ]
 }

--- a/Calculadora/src/App.cpp
+++ b/Calculadora/src/App.cpp
@@ -167,8 +167,8 @@ void App::importarCSV() {
 }
 
 bool App::carregarJSON() {
-    int version = 0;
-    if (!Persist::loadJSON("materiais.json", base, &version) || base.empty()) {
+    int schemaVersion = 0;
+    if (!Persist::loadJSON("materiais.json", base, &schemaVersion) || base.empty()) {
         wr::p("DATA", "Base nao encontrada. Criando materiais padrao...", "Yellow");
         base = {
             {"Pinus 20cm", 17.00, 0.20, 3.00},
@@ -181,7 +181,7 @@ bool App::carregarJSON() {
         }
     } else {
         std::ostringstream oss;
-        oss << "materiais.json carregado (versao " << version << ")";
+        oss << "materiais.json carregado (versao " << schemaVersion << ")";
         wr::p("DATA", oss.str(), "Green");
     }
 

--- a/Calculadora/tests/data/ok.json
+++ b/Calculadora/tests/data/ok.json
@@ -1,11 +1,12 @@
 {
+  "schema_version": 1,
   "materiais": [
     {
-      "comprimento": 3.0,
-      "largura": 2.0,
       "nome": "Madeira",
-      "valor": 10.0
+      "tipo": "linear",
+      "valor": 10.0,
+      "largura": 2.0,
+      "comprimento": 3.0
     }
-  ],
-  "version": 1
+  ]
 }

--- a/Calculadora/tests/data/ok.json.bak
+++ b/Calculadora/tests/data/ok.json.bak
@@ -1,11 +1,12 @@
 {
+  "schema_version": 1,
   "materiais": [
     {
-      "comprimento": 3.0,
-      "largura": 2.0,
       "nome": "Madeira",
-      "valor": 10.0
+      "tipo": "linear",
+      "valor": 10.0,
+      "largura": 2.0,
+      "comprimento": 3.0
     }
-  ],
-  "version": 1
+  ]
 }

--- a/Calculadora/tests/persist_io_test.cpp
+++ b/Calculadora/tests/persist_io_test.cpp
@@ -10,7 +10,9 @@ void test_persist_io() {
     // Salva e carrega JSON
     assert(Persist::saveJSON("teste_io.json", itens));
     std::vector<MaterialDTO> carregado;
-    assert(Persist::loadJSON("teste_io.json", carregado));
+    int schemaVersion = 0;
+    assert(Persist::loadJSON("teste_io.json", carregado, &schemaVersion));
+    assert(schemaVersion == 1);
     assert(carregado.size() == 1);
     assert(carregado[0].nome == "Madeira");
     assert(carregado[0].tipo == "linear");


### PR DESCRIPTION
## Summary
- add `tipo` field to MaterialDTO persistence with migration and schema versioning
- persist and read `schema_version` for material JSON files
- update materiais data and tests for new field

## Testing
- `make`
- `make -C tests`
- `./tests/run_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a2891ef9b88327944fc4294b353e54