### PR TITLE
[domain] feat: adicionar materiais básicos

### DIFF
--- a/Calculadora/Makefile
+++ b/Calculadora/Makefile
@@ -2,7 +2,7 @@ CXX = g++
 CXXFLAGS = -std=c++17 -Wall
 INCLUDES = -Iinclude -Ithird_party
 
-SRC := $(wildcard src/*.cpp)
+SRC := $(wildcard src/*.cpp) $(wildcard src/domain/*.cpp)
 
 app: $(SRC)
 	$(CXX) $(CXXFLAGS) $(SRC) $(INCLUDES) -o $@

--- a/Calculadora/include/domain/MaterialBase.h
+++ b/Calculadora/include/domain/MaterialBase.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+
+// Estrutura com medidas de um item
+struct Medidas {
+    double largura = 0.0;       // em metros
+    double altura = 0.0;        // em metros
+    double profundidade = 0.0;  // em metros
+    double comprimento = 0.0;   // em metros (usado para materiais lineares)
+};
+
+// Classe base para diferentes tipos de materiais
+class MaterialBase {
+public:
+    virtual ~MaterialBase() = default;
+
+    // Retorna o tipo do material
+    virtual std::string tipo() const = 0;
+
+    // Calcula o custo total dado uma quantidade e medidas
+    virtual double custo(double qtd, const Medidas& m) const = 0;
+};

--- a/Calculadora/include/domain/MaterialCubico.h
+++ b/Calculadora/include/domain/MaterialCubico.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "domain/MaterialBase.h"
+
+// Material vendido por metro cúbico
+class MaterialCubico : public MaterialBase {
+    double precoM3 = 0.0; // preco por metro cubico
+
+public:
+    explicit MaterialCubico(double preco);
+
+    std::string tipo() const override;
+    double custo(double qtd, const Medidas& m) const override;
+};

--- a/Calculadora/include/domain/MaterialLinear.h
+++ b/Calculadora/include/domain/MaterialLinear.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "domain/MaterialBase.h"
+
+// Material vendido por metro linear
+class MaterialLinear : public MaterialBase {
+    double precoM = 0.0; // preco por metro
+    double perda = 0.0;  // percentual de perda (0.1 = 10%)
+
+public:
+    MaterialLinear(double preco, double perdaPct);
+
+    std::string tipo() const override;
+    double custo(double qtd, const Medidas& m) const override;
+};

--- a/Calculadora/include/domain/MaterialUnitario.h
+++ b/Calculadora/include/domain/MaterialUnitario.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "domain/MaterialBase.h"
+
+// Material vendido por unidade
+class MaterialUnitario : public MaterialBase {
+    double precoUnitario = 0.0; // preco por unidade
+
+public:
+    explicit MaterialUnitario(double preco);
+
+    std::string tipo() const override;
+    double custo(double qtd, const Medidas& m) const override;
+};

--- a/Calculadora/src/domain/MaterialCubico.cpp
+++ b/Calculadora/src/domain/MaterialCubico.cpp
@@ -1,0 +1,17 @@
+#include "domain/MaterialCubico.h"
+
+// Construtor com preco por metro cubico
+// Exemplo: MaterialCubico mc(100.0);
+MaterialCubico::MaterialCubico(double preco)
+    : precoM3(preco) {}
+
+// Retorna o identificador do tipo
+// Exemplo: mc.tipo() => "cubico"
+std::string MaterialCubico::tipo() const { return "cubico"; }
+
+// Calcula o custo total a partir do volume
+// Exemplo: precoM3=100, L=2, A=0.5, P=1, qtd=3 => 100*1*3=300
+double MaterialCubico::custo(double qtd, const Medidas& m) const {
+    double volume = m.largura * m.altura * m.profundidade;
+    return precoM3 * volume * qtd;
+}

--- a/Calculadora/src/domain/MaterialLinear.cpp
+++ b/Calculadora/src/domain/MaterialLinear.cpp
@@ -1,0 +1,17 @@
+#include "domain/MaterialLinear.h"
+
+// Construtor com preco por metro e percentual de perda
+// Exemplo: MaterialLinear ml(10.0, 0.1);
+MaterialLinear::MaterialLinear(double preco, double perdaPct)
+    : precoM(preco), perda(perdaPct) {}
+
+// Retorna o identificador do tipo
+// Exemplo: ml.tipo() => "linear"
+std::string MaterialLinear::tipo() const { return "linear"; }
+
+// Calcula o custo total considerando perda
+// Exemplo: precoM=10, perda=0.1, metros=2, qtd=4 => 10*2*4*1.1=88
+double MaterialLinear::custo(double qtd, const Medidas& m) const {
+    double metros = m.comprimento;
+    return precoM * metros * qtd * (1.0 + perda);
+}

--- a/Calculadora/src/domain/MaterialUnitario.cpp
+++ b/Calculadora/src/domain/MaterialUnitario.cpp
@@ -1,0 +1,16 @@
+#include "domain/MaterialUnitario.h"
+
+// Construtor com preco por unidade
+// Exemplo: MaterialUnitario mu(5.0);
+MaterialUnitario::MaterialUnitario(double preco)
+    : precoUnitario(preco) {}
+
+// Retorna o identificador do tipo
+// Exemplo: mu.tipo() => "unitario"
+std::string MaterialUnitario::tipo() const { return "unitario"; }
+
+// Calcula o custo total
+// Exemplo: precoUnitario=5.0, qtd=3 => custo=15.0
+double MaterialUnitario::custo(double qtd, const Medidas&) const {
+    return precoUnitario * qtd;
+}

--- a/Calculadora/tests/Makefile
+++ b/Calculadora/tests/Makefile
@@ -3,7 +3,11 @@ CXXFLAGS = -std=c++17 -Wall -DUNIT_TEST
 INCLUDES = -I../include -I../third_party
 
 TEST_SRCS = $(wildcard *.cpp)
-SRC_FILES = ../src/Material.cpp ../src/Corte.cpp ../src/cli.cpp ../src/plano_corte.cpp ../src/persist.cpp
+SRC_FILES = ../src/Material.cpp ../src/Corte.cpp ../src/cli.cpp \
+            ../src/plano_corte.cpp ../src/persist.cpp \
+            ../src/domain/MaterialUnitario.cpp \
+            ../src/domain/MaterialLinear.cpp \
+            ../src/domain/MaterialCubico.cpp
 
 run_tests: $(TEST_SRCS) $(SRC_FILES)
 	$(CXX) $(CXXFLAGS) $(TEST_SRCS) $(SRC_FILES) $(INCLUDES) -o run_tests

--- a/Calculadora/tests/domain_material_test.cpp
+++ b/Calculadora/tests/domain_material_test.cpp
@@ -1,0 +1,30 @@
+#include "domain/MaterialUnitario.h"
+#include "domain/MaterialLinear.h"
+#include "domain/MaterialCubico.h"
+#include <cassert>
+
+// Testa as subclasses de MaterialBase
+void test_domain_material() {
+    // Material unitario
+    MaterialUnitario mu(5.0);
+    assert(mu.tipo() == "unitario");
+    assert(mu.custo(3, Medidas{}) == 15.0);
+
+    // Material linear com 10% de perda
+    MaterialLinear ml(10.0, 0.1);
+    Medidas m1;
+    m1.comprimento = 2.0;
+    double custoLinear = ml.custo(4, m1);
+    assert(ml.tipo() == "linear");
+    assert(custoLinear == 88.0);
+
+    // Material cubico
+    MaterialCubico mc(100.0);
+    Medidas m2;
+    m2.largura = 2.0;
+    m2.altura = 0.5;
+    m2.profundidade = 1.0;
+    double custoCubico = mc.custo(3, m2);
+    assert(mc.tipo() == "cubico");
+    assert(custoCubico == 300.0);
+}

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -12,6 +12,7 @@ void test_persist_helpers();
 void test_plano_io();
 void test_plano_index();
 void test_data_path();
+void test_domain_material();
 
 // Executa todos os testes
 int main() {
@@ -26,5 +27,6 @@ int main() {
     test_plano_io();
     test_plano_index();
     test_data_path();
+    test_domain_material();
     return 0;
 }


### PR DESCRIPTION
## Summary
- add MaterialBase interface and domain measurements structure
- implement unitary, linear and cubic material costing
- test material costing formulas

## Testing
- `make`
- `make clean && make` (tests)
- `./run_tests`

### Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a28b0c22b88327ba500f469b94d356