### PR TITLE
[domain] feat: adicionar MaterialFactory

### DIFF
--- a/Calculadora/include/domain/MaterialFactory.h
+++ b/Calculadora/include/domain/MaterialFactory.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <memory>
+#include "domain/MaterialBase.h"
+#include "persist.h"
+
+// Factory para criar materiais a partir de um MaterialDTO
+class MaterialFactory {
+public:
+    // Instancia o material concreto baseado no campo tipo do DTO
+    // Exemplo:
+    //   MaterialDTO d{"Madeira", 5.0, 0, 0, "unitario"};
+    //   auto mat = MaterialFactory::fromDTO(d);
+    static std::unique_ptr<MaterialBase> fromDTO(const MaterialDTO& dto);
+};

--- a/Calculadora/src/domain/MaterialFactory.cpp
+++ b/Calculadora/src/domain/MaterialFactory.cpp
@@ -1,0 +1,20 @@
+#include "domain/MaterialFactory.h"
+#include "domain/MaterialUnitario.h"
+#include "domain/MaterialLinear.h"
+#include "domain/MaterialCubico.h"
+#include <stdexcept>
+
+// Cria instância concreta conforme o tipo informado
+// Exemplo: fromDTO({"Item",10,0,0,"unitario"}) -> MaterialUnitario
+std::unique_ptr<MaterialBase> MaterialFactory::fromDTO(const MaterialDTO& dto) {
+    if (dto.tipo == "unitario") {
+        return std::make_unique<MaterialUnitario>(dto.valor);
+    }
+    if (dto.tipo == "linear") {
+        return std::make_unique<MaterialLinear>(dto.valor, 0.0);
+    }
+    if (dto.tipo == "cubico") {
+        return std::make_unique<MaterialCubico>(dto.valor);
+    }
+    throw std::invalid_argument("tipo desconhecido: " + dto.tipo);
+}

--- a/Calculadora/tests/Makefile
+++ b/Calculadora/tests/Makefile
@@ -7,7 +7,8 @@ SRC_FILES = ../src/Material.cpp ../src/Corte.cpp ../src/cli.cpp \
             ../src/plano_corte.cpp ../src/persist.cpp \
             ../src/domain/MaterialUnitario.cpp \
             ../src/domain/MaterialLinear.cpp \
-            ../src/domain/MaterialCubico.cpp
+            ../src/domain/MaterialCubico.cpp \
+            ../src/domain/MaterialFactory.cpp
 
 run_tests: $(TEST_SRCS) $(SRC_FILES)
 	$(CXX) $(CXXFLAGS) $(TEST_SRCS) $(SRC_FILES) $(INCLUDES) -o run_tests

--- a/Calculadora/tests/material_factory_test.cpp
+++ b/Calculadora/tests/material_factory_test.cpp
@@ -1,0 +1,31 @@
+#include "domain/MaterialFactory.h"
+#include <cassert>
+
+// Testa MaterialFactory::fromDTO
+void test_material_factory() {
+    // unitario
+    MaterialDTO du{"ItemU", 5.0, 0.0, 0.0, "unitario"};
+    auto mu = MaterialFactory::fromDTO(du);
+    assert(mu->tipo() == "unitario");
+
+    // linear
+    MaterialDTO dl{"ItemL", 10.0, 0.0, 0.0, "linear"};
+    auto ml = MaterialFactory::fromDTO(dl);
+    assert(ml->tipo() == "linear");
+
+    // cubico
+    MaterialDTO dc{"ItemC", 100.0, 0.0, 0.0, "cubico"};
+    auto mc = MaterialFactory::fromDTO(dc);
+    assert(mc->tipo() == "cubico");
+
+    // tipo invalido
+    MaterialDTO di{"Inv", 1.0, 0.0, 0.0, "foo"};
+    bool errou = false;
+    try {
+        auto bad = MaterialFactory::fromDTO(di);
+        (void)bad;
+    } catch (const std::invalid_argument&) {
+        errou = true;
+    }
+    assert(errou);
+}

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -13,6 +13,7 @@ void test_plano_io();
 void test_plano_index();
 void test_data_path();
 void test_domain_material();
+void test_material_factory();
 
 // Executa todos os testes
 int main() {
@@ -28,5 +29,6 @@ int main() {
     test_plano_index();
     test_data_path();
     test_domain_material();
+    test_material_factory();
     return 0;
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -33,6 +33,11 @@ Com a evolução recente, a camada de persistência agora:
 - Permite reabrir planos salvos com `loadPlanoJSON`.
 - Expande `MaterialDTO` com campo `tipo` e migração para arquivos antigos.
 
+## Domínio de Materiais
+
+- Implementadas classes específicas para materiais `unitário`, `linear` e `cúbico`. ✅
+- Adicionada `MaterialFactory::fromDTO` para instanciar o tipo correto a partir de `MaterialDTO`. ✅
+
 ## Melhorias propostas
 
 - Documentação expandida em `docs/` para cobrir uso e desenvolvimento.


### PR DESCRIPTION
## Summary
- create MaterialFactory to instanciar materiais conforme MaterialDTO
- cobrir cada tipo e erro em MaterialFactory
- documentar funcionalidade no roadmap

## Testing
- `make -C Calculadora`
- `make -C Calculadora/tests`
- `./Calculadora/tests/run_tests`

### Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a2f602ee608327af0c5e48a23780fb