### PR TITLE
[custo] feat: estimador de custo básico

### DIFF
--- a/Calculadora/Makefile
+++ b/Calculadora/Makefile
@@ -2,7 +2,7 @@ CXX = g++
 CXXFLAGS = -std=c++17 -Wall
 INCLUDES = -Iinclude -Ithird_party
 
-SRC := $(wildcard src/*.cpp) $(wildcard src/domain/*.cpp)
+SRC := $(wildcard src/*.cpp) $(wildcard src/domain/*.cpp) $(wildcard src/custo/*.cpp)
 
 app: $(SRC)
 	$(CXX) $(CXXFLAGS) $(SRC) $(INCLUDES) -o $@

--- a/Calculadora/include/custo/CustoParams.h
+++ b/Calculadora/include/custo/CustoParams.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// Parâmetros globais para cálculo de custo
+struct CustoParams {
+    double perdaPadrao = 0.0;   // percentual de perda aplicado a todos os itens
+    double fatorMaoObra = 0.0;  // fator multiplicador de mão de obra
+    double markup = 0.0;        // percentual de markup/lucro
+    int casasDecimais = 2;      // casas decimais do resultado
+};
+
+// Exemplo de uso:
+// CustoParams cfg{0.05, 0.1, 0.2, 2};

--- a/Calculadora/include/custo/EstimadorCusto.h
+++ b/Calculadora/include/custo/EstimadorCusto.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "custo/CustoParams.h"
+#include "domain/MaterialBase.h"
+
+// Item requisitado com identificação e medidas
+struct ItemReq {
+    std::string idMaterial;    // identificador do material
+    std::string tipoMaterial;  // tipo do material (unitario/linear/cubico)
+    double qtd = 0.0;          // quantidade necessária
+    Medidas medidas;           // medidas relevantes
+};
+
+// Descrição de um item de corte
+struct ItemCorte {
+    std::string nome;          // identificação do corte
+    double largura = 0.0;      // em metros
+    double comprimento = 0.0;  // em metros
+    double profundidade = 0.0; // em metros (opcional)
+    double qtd = 0.0;          // quantidade de peças
+    std::string idMaterial;    // material associado (opcional)
+};
+
+// Item de projeto com material já referenciado
+struct ProjetoItem {
+    ItemReq req;                   // requisição do item
+    const MaterialBase* material;  // ponteiro para material existente
+};
+
+// Projeto composto por itens de materiais
+struct Projeto {
+    std::vector<ProjetoItem> materiais;  // itens de material do projeto
+};
+
+// Classe responsável por estimar custos
+class EstimadorCusto {
+public:
+    // Calcula o custo de um material específico
+    // Exemplo: custoMaterial(req, mat)
+    double custoMaterial(const ItemReq& req, const MaterialBase& m) const;
+
+    // Calcula o custo total de um projeto aplicando parâmetros globais
+    // Exemplo: custoProjeto(prj, cfg)
+    double custoProjeto(const Projeto& prj, const CustoParams& cfg) const;
+};
+

--- a/Calculadora/src/custo/EstimadorCusto.cpp
+++ b/Calculadora/src/custo/EstimadorCusto.cpp
@@ -1,0 +1,32 @@
+#include "custo/EstimadorCusto.h"
+
+#include <cmath>
+
+// Calcula o custo de um material específico
+// Exemplo: ItemReq req{...}; MaterialUnitario m(5.0);
+// EstimadorCusto est; est.custoMaterial(req, m);
+double EstimadorCusto::custoMaterial(const ItemReq& req, const MaterialBase& m) const {
+    return m.custo(req.qtd, req.medidas);
+}
+
+// Função auxiliar para arredondar
+static double arredondar(double valor, int casas) {
+    double fator = std::pow(10.0, casas);
+    return std::round(valor * fator) / fator;
+}
+
+// Calcula o custo total do projeto
+// Exemplo: EstimadorCusto est; est.custoProjeto(prj, cfg);
+double EstimadorCusto::custoProjeto(const Projeto& prj, const CustoParams& cfg) const {
+    double subtotal = 0.0;
+    for (const auto& item : prj.materiais) {
+        if (item.material != nullptr) {
+            subtotal += custoMaterial(item.req, *item.material);
+        }
+    }
+    subtotal *= (1.0 + cfg.perdaPadrao);
+    subtotal *= (1.0 + cfg.fatorMaoObra);
+    subtotal *= (1.0 + cfg.markup);
+    return arredondar(subtotal, cfg.casasDecimais);
+}
+

--- a/Calculadora/tests/Makefile
+++ b/Calculadora/tests/Makefile
@@ -8,7 +8,8 @@ SRC_FILES = ../src/Material.cpp ../src/Corte.cpp ../src/cli.cpp \
             ../src/domain/MaterialUnitario.cpp \
             ../src/domain/MaterialLinear.cpp \
             ../src/domain/MaterialCubico.cpp \
-            ../src/domain/MaterialFactory.cpp
+            ../src/domain/MaterialFactory.cpp \
+            ../src/custo/EstimadorCusto.cpp
 
 run_tests: $(TEST_SRCS) $(SRC_FILES)
 	$(CXX) $(CXXFLAGS) $(TEST_SRCS) $(SRC_FILES) $(INCLUDES) -o run_tests

--- a/Calculadora/tests/estimador_custo_test.cpp
+++ b/Calculadora/tests/estimador_custo_test.cpp
@@ -1,0 +1,40 @@
+#include "custo/EstimadorCusto.h"
+#include "domain/MaterialUnitario.h"
+#include "domain/MaterialLinear.h"
+#include "domain/MaterialCubico.h"
+#include <cassert>
+
+// Testa o EstimadorCusto com diferentes tipos de materiais
+void test_estimador_custo() {
+    EstimadorCusto est;
+
+    // Material unitário
+    MaterialUnitario mu(5.0);
+    ItemReq reqU{"MAT-U", "unitario", 3.0, {}};
+    double custoU = est.custoMaterial(reqU, mu);
+    assert(custoU == 15.0);
+
+    // Material linear com perda interna de 10%
+    MaterialLinear ml(10.0, 0.1);
+    ItemReq reqL{"MAT-L", "linear", 4.0, {0.0, 0.0, 0.0, 2.0}};
+    double custoL = est.custoMaterial(reqL, ml);
+    assert(custoL == 88.0);
+
+    // Material cúbico
+    MaterialCubico mc(100.0);
+    Medidas m3{2.0, 0.5, 1.0, 0.0};
+    ItemReq reqC{"MAT-C", "cubico", 3.0, m3};
+    double custoC = est.custoMaterial(reqC, mc);
+    assert(custoC == 300.0);
+
+    // Projeto agregando os três itens
+    Projeto prj;
+    prj.materiais.push_back({reqU, &mu});
+    prj.materiais.push_back({reqL, &ml});
+    prj.materiais.push_back({reqC, &mc});
+
+    CustoParams cfg{0.05, 0.1, 0.2, 2};
+    double total = est.custoProjeto(prj, cfg);
+    assert(total == 558.56);
+}
+

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -14,6 +14,7 @@ void test_plano_index();
 void test_data_path();
 void test_domain_material();
 void test_material_factory();
+void test_estimador_custo();
 
 // Executa todos os testes
 int main() {
@@ -30,5 +31,6 @@ int main() {
     test_data_path();
     test_domain_material();
     test_material_factory();
+    test_estimador_custo();
     return 0;
 }


### PR DESCRIPTION
## Resumo
- adicionar `CustoParams` para configurar perdas, mão de obra e markup
- implementar `EstimadorCusto` com cálculo de material e projeto
- cobrir materiais unitário, linear e cúbico com testes

## Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a2f8788a8483279bdc0cc746647853