### PR TITLE
[domain] feat: persistência de projetos

### DIFF
--- a/Calculadora/include/custo/EstimadorCusto.h
+++ b/Calculadora/include/custo/EstimadorCusto.h
@@ -31,7 +31,7 @@ struct ProjetoItem {
 };
 
 // Projeto composto por itens de materiais
-struct Projeto {
+struct ProjetoCusto {
     std::vector<ProjetoItem> materiais;  // itens de material do projeto
 };
 
@@ -44,6 +44,6 @@ public:
 
     // Calcula o custo total de um projeto aplicando parâmetros globais
     // Exemplo: custoProjeto(prj, cfg)
-    double custoProjeto(const Projeto& prj, const CustoParams& cfg) const;
+    double custoProjeto(const ProjetoCusto& prj, const CustoParams& cfg) const;
 };
 

--- a/Calculadora/include/domain/Projeto.h
+++ b/Calculadora/include/domain/Projeto.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "domain/MaterialBase.h"
+
+// Item de material dentro de um projeto
+struct ProjetoItemMaterial {
+    std::string idMaterial;    // identificador do material
+    double quantidade = 0.0;   // quantidade necessária
+    Medidas medidas;           // medidas relevantes
+    double custoUnitario = 0.0; // custo de cada unidade
+};
+
+// Item de corte associado a um material
+struct ProjetoItemCorte {
+    std::string idMaterial;    // material do corte
+    double largura = 0.0;      // largura em metros
+    double comprimento = 0.0;  // comprimento em metros
+    double quantidade = 0.0;   // número de peças
+    double custoUnitario = 0.0;// custo por peça
+};
+
+// Representa um projeto completo
+class Projeto {
+public:
+    std::string id;                 // identificador único
+    std::string nome;               // nome do projeto
+    std::vector<ProjetoItemMaterial> materiais; // itens de material
+    std::vector<ProjetoItemCorte> cortes;       // itens de corte
+
+    // Adiciona um material ao projeto. Retorna falso em caso de validação falha.
+    // Exemplo:
+    //   ProjetoItemMaterial it{"madeira", 2, {}, 10.0};
+    //   prj.adicionarMaterial(it);
+    bool adicionarMaterial(const ProjetoItemMaterial& item);
+
+    // Adiciona um corte ao projeto. Retorna falso se medidas inválidas.
+    bool adicionarCorte(const ProjetoItemCorte& item);
+
+    // Remove todos os itens associados ao idMaterial informado.
+    bool removerItem(const std::string& idMaterial);
+
+    // Calcula o custo total do projeto.
+    double resumoCusto() const;
+};
+

--- a/Calculadora/include/persist/projeto.hpp
+++ b/Calculadora/include/persist/projeto.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "domain/Projeto.h"
+
+namespace Persist {
+
+// Salva o projeto em JSON dentro de data/projetos/<id>/projeto.json
+bool saveProjetoJSON(const Projeto& projeto);
+
+// Carrega projeto pelo identificador
+bool loadProjetoJSON(const std::string& id, Projeto& out);
+
+// Lista ids de projetos existentes
+std::vector<std::string> listarProjetos();
+
+// Remove o projeto e sua entrada no índice
+bool deleteProjeto(const std::string& id);
+
+} // namespace Persist
+

--- a/Calculadora/src/custo/EstimadorCusto.cpp
+++ b/Calculadora/src/custo/EstimadorCusto.cpp
@@ -17,7 +17,7 @@ static double arredondar(double valor, int casas) {
 
 // Calcula o custo total do projeto
 // Exemplo: EstimadorCusto est; est.custoProjeto(prj, cfg);
-double EstimadorCusto::custoProjeto(const Projeto& prj, const CustoParams& cfg) const {
+double EstimadorCusto::custoProjeto(const ProjetoCusto& prj, const CustoParams& cfg) const {
     double subtotal = 0.0;
     for (const auto& item : prj.materiais) {
         if (item.material != nullptr) {

--- a/Calculadora/src/domain/Projeto.cpp
+++ b/Calculadora/src/domain/Projeto.cpp
@@ -1,0 +1,50 @@
+#include "domain/Projeto.h"
+
+#include <algorithm>
+
+// Valida se medidas são estritamente positivas
+static bool medidasValidas(const Medidas& m) {
+    if (m.largura <= 0 && m.altura <= 0 && m.profundidade <= 0 && m.comprimento <= 0)
+        return false;
+    if (m.largura < 0 || m.altura < 0 || m.profundidade < 0 || m.comprimento < 0)
+        return false;
+    return true;
+}
+
+bool Projeto::adicionarMaterial(const ProjetoItemMaterial& item) {
+    if (item.idMaterial.empty()) return false;
+    if (item.quantidade <= 0) return false;
+    if (!medidasValidas(item.medidas)) return false;
+    materiais.push_back(item);
+    return true;
+}
+
+bool Projeto::adicionarCorte(const ProjetoItemCorte& item) {
+    if (item.idMaterial.empty()) return false;
+    if (item.largura <= 0 || item.comprimento <= 0) return false;
+    if (item.quantidade <= 0) return false;
+    cortes.push_back(item);
+    return true;
+}
+
+bool Projeto::removerItem(const std::string& idMaterial) {
+    auto beforeM = materiais.size();
+    materiais.erase(std::remove_if(materiais.begin(), materiais.end(), [&](const auto& m){return m.idMaterial == idMaterial;}), materiais.end());
+    auto removed = materiais.size() != beforeM;
+    auto beforeC = cortes.size();
+    cortes.erase(std::remove_if(cortes.begin(), cortes.end(), [&](const auto& c){return c.idMaterial == idMaterial;}), cortes.end());
+    removed = removed || (cortes.size() != beforeC);
+    return removed;
+}
+
+double Projeto::resumoCusto() const {
+    double total = 0.0;
+    for (const auto& m : materiais) {
+        total += m.quantidade * m.custoUnitario;
+    }
+    for (const auto& c : cortes) {
+        total += c.quantidade * c.custoUnitario;
+    }
+    return total;
+}
+

--- a/Calculadora/src/persist_projeto.cpp
+++ b/Calculadora/src/persist_projeto.cpp
@@ -1,0 +1,168 @@
+#include "persist/projeto.hpp"
+#include "persist.h"
+
+#include <filesystem>
+#include <fstream>
+
+using nlohmann::json;
+namespace fs = std::filesystem;
+
+// Converte Projeto para JSON
+static json projetoToJson(const Projeto& p) {
+    json j;
+    j["id"] = p.id;
+    j["nome"] = p.nome;
+    j["materiais"] = json::array();
+    for (const auto& m : p.materiais) {
+        j["materiais"].push_back({
+            {"id_material", m.idMaterial},
+            {"quantidade", m.quantidade},
+            {"custo_unitario", m.custoUnitario},
+            {"medidas", {
+                {"largura", m.medidas.largura},
+                {"altura", m.medidas.altura},
+                {"profundidade", m.medidas.profundidade},
+                {"comprimento", m.medidas.comprimento}
+            }}
+        });
+    }
+    j["cortes"] = json::array();
+    for (const auto& c : p.cortes) {
+        j["cortes"].push_back({
+            {"id_material", c.idMaterial},
+            {"largura", c.largura},
+            {"comprimento", c.comprimento},
+            {"quantidade", c.quantidade},
+            {"custo_unitario", c.custoUnitario}
+        });
+    }
+    return j;
+}
+
+static void jsonToProjeto(const json& j, Projeto& p) {
+    j.at("id").get_to(p.id);
+    if (j.contains("nome")) j.at("nome").get_to(p.nome);
+    p.materiais.clear();
+    for (const auto& jm : j.value("materiais", json::array())) {
+        ProjetoItemMaterial m;
+        jm.at("id_material").get_to(m.idMaterial);
+        jm.at("quantidade").get_to(m.quantidade);
+        jm.at("custo_unitario").get_to(m.custoUnitario);
+        auto med = jm.at("medidas");
+        med.at("largura").get_to(m.medidas.largura);
+        med.at("altura").get_to(m.medidas.altura);
+        med.at("profundidade").get_to(m.medidas.profundidade);
+        med.at("comprimento").get_to(m.medidas.comprimento);
+        p.materiais.push_back(m);
+    }
+    p.cortes.clear();
+    for (const auto& jc : j.value("cortes", json::array())) {
+        ProjetoItemCorte c;
+        jc.at("id_material").get_to(c.idMaterial);
+        jc.at("largura").get_to(c.largura);
+        jc.at("comprimento").get_to(c.comprimento);
+        jc.at("quantidade").get_to(c.quantidade);
+        jc.at("custo_unitario").get_to(c.custoUnitario);
+        p.cortes.push_back(c);
+    }
+}
+
+static fs::path projetoPath(const std::string& id) {
+    return fs::path(Persist::dataPath("projetos/" + id + "/projeto.json"));
+}
+
+static fs::path indexPath() {
+    return fs::path(Persist::dataPath("projetos/index.json"));
+}
+
+bool Persist::saveProjetoJSON(const Projeto& projeto) {
+    try {
+        json j = projetoToJson(projeto);
+        if (!Persist::atomicWrite(projetoPath(projeto.id), j.dump(2))) return false;
+
+        json idx;
+        if (fs::exists(indexPath())) {
+            std::ifstream f(indexPath());
+            if (f) { try { f >> idx; } catch (...) { idx = json{}; } }
+        }
+        if (!idx.is_object()) idx = json::object();
+        if (!idx.contains("projetos") || !idx["projetos"].is_array())
+            idx["projetos"] = json::array();
+        bool found = false;
+        for (const auto& idj : idx["projetos"]) {
+            if (idj.is_string() && idj.get<std::string>() == projeto.id) {
+                found = true; break;
+            }
+        }
+        if (!found) idx["projetos"].push_back(projeto.id);
+        return Persist::atomicWrite(indexPath(), idx.dump(2));
+    } catch (const std::exception& e) {
+        wr::p("PERSIST", std::string("saveProjetoJSON exception: ") + e.what(), "Red");
+        return false;
+    } catch (...) {
+        wr::p("PERSIST", "saveProjetoJSON unknown exception", "Red");
+        return false;
+    }
+}
+
+bool Persist::loadProjetoJSON(const std::string& id, Projeto& out) {
+    try {
+        std::ifstream f(projetoPath(id));
+        if (!f) {
+            wr::p("PERSIST", "loadProjetoJSON open fail", "Red");
+            return false;
+        }
+        json j; f >> j;
+        jsonToProjeto(j, out);
+        return true;
+    } catch (const std::exception& e) {
+        wr::p("PERSIST", std::string("loadProjetoJSON exception: ") + e.what(), "Red");
+        return false;
+    } catch (...) {
+        wr::p("PERSIST", "loadProjetoJSON unknown exception", "Red");
+        return false;
+    }
+}
+
+std::vector<std::string> Persist::listarProjetos() {
+    std::vector<std::string> ids;
+    try {
+        if (!fs::exists(indexPath())) return ids;
+        std::ifstream f(indexPath());
+        if (!f) return ids;
+        json j; f >> j;
+        for (const auto& idj : j.value("projetos", json::array())) {
+            if (idj.is_string()) ids.push_back(idj.get<std::string>());
+        }
+    } catch (...) {
+        // retorna lista vazia em caso de erro
+    }
+    return ids;
+}
+
+bool Persist::deleteProjeto(const std::string& id) {
+    bool ok = true;
+    try {
+        fs::remove_all(fs::path(Persist::dataPath("projetos/" + id)));
+        json idx;
+        if (fs::exists(indexPath())) {
+            std::ifstream f(indexPath());
+            if (f) { try { f >> idx; } catch (...) { idx = json{}; } }
+        }
+        if (idx.is_object() && idx.contains("projetos")) {
+            auto& arr = idx["projetos"];
+            if (arr.is_array()) {
+                arr.erase(std::remove_if(arr.begin(), arr.end(), [&](const json& v){return v.is_string() && v.get<std::string>() == id;}), arr.end());
+                ok = Persist::atomicWrite(indexPath(), idx.dump(2));
+            }
+        }
+    } catch (const std::exception& e) {
+        wr::p("PERSIST", std::string("deleteProjeto exception: ") + e.what(), "Red");
+        ok = false;
+    } catch (...) {
+        wr::p("PERSIST", "deleteProjeto unknown exception", "Red");
+        ok = false;
+    }
+    return ok;
+}
+

--- a/Calculadora/tests/Makefile
+++ b/Calculadora/tests/Makefile
@@ -5,10 +5,12 @@ INCLUDES = -I../include -I../third_party
 TEST_SRCS = $(wildcard *.cpp)
 SRC_FILES = ../src/Material.cpp ../src/Corte.cpp ../src/cli.cpp \
             ../src/plano_corte.cpp ../src/persist.cpp \
+            ../src/persist_projeto.cpp \
             ../src/domain/MaterialUnitario.cpp \
             ../src/domain/MaterialLinear.cpp \
             ../src/domain/MaterialCubico.cpp \
             ../src/domain/MaterialFactory.cpp \
+            ../src/domain/Projeto.cpp \
             ../src/custo/EstimadorCusto.cpp
 
 run_tests: $(TEST_SRCS) $(SRC_FILES)

--- a/Calculadora/tests/estimador_custo_test.cpp
+++ b/Calculadora/tests/estimador_custo_test.cpp
@@ -28,7 +28,7 @@ void test_estimador_custo() {
     assert(custoC == 300.0);
 
     // Projeto agregando os três itens
-    Projeto prj;
+    ProjetoCusto prj;
     prj.materiais.push_back({reqU, &mu});
     prj.materiais.push_back({reqL, &ml});
     prj.materiais.push_back({reqC, &mc});

--- a/Calculadora/tests/projeto_test.cpp
+++ b/Calculadora/tests/projeto_test.cpp
@@ -1,0 +1,73 @@
+#include "domain/Projeto.h"
+#include "persist/projeto.hpp"
+#include <cassert>
+#include <filesystem>
+
+void test_projeto() {
+    Projeto prj;
+    prj.id = "proj_teste";
+    prj.nome = "Projeto Teste";
+
+    // Material válido
+    ProjetoItemMaterial mat;
+    mat.idMaterial = "mat1";
+    mat.quantidade = 2;
+    mat.custoUnitario = 5.0;
+    mat.medidas.largura = 1.0;
+    mat.medidas.comprimento = 1.0;
+    assert(prj.adicionarMaterial(mat));
+
+    // Material inválido (id vazio)
+    ProjetoItemMaterial inval;
+    inval.quantidade = 1;
+    inval.medidas.largura = 1.0;
+    inval.medidas.comprimento = 1.0;
+    assert(!prj.adicionarMaterial(inval));
+
+    // Corte válido
+    ProjetoItemCorte ct;
+    ct.idMaterial = "mat1";
+    ct.largura = 0.5;
+    ct.comprimento = 0.5;
+    ct.quantidade = 1;
+    ct.custoUnitario = 1.0;
+    assert(prj.adicionarCorte(ct));
+
+    // Corte inválido (medida <=0)
+    ProjetoItemCorte ctInv;
+    ctInv.idMaterial = "mat1";
+    ctInv.largura = 0.0;
+    ctInv.comprimento = 1.0;
+    ctInv.quantidade = 1;
+    assert(!prj.adicionarCorte(ctInv));
+
+    // Resumo de custo
+    assert(prj.resumoCusto() == 2*5.0 + 1*1.0);
+
+    // Remoção
+    assert(prj.removerItem("mat1"));
+    assert(prj.materiais.empty());
+    assert(prj.cortes.empty());
+
+    // Testes de persistência
+    prj.adicionarMaterial(mat);
+    prj.adicionarCorte(ct);
+    assert(Persist::saveProjetoJSON(prj));
+
+    Projeto lido;
+    assert(Persist::loadProjetoJSON(prj.id, lido));
+    assert(lido.materiais.size() == 1);
+    assert(lido.cortes.size() == 1);
+
+    auto ids = Persist::listarProjetos();
+    bool encontrado = false;
+    for (const auto& id : ids) if (id == prj.id) encontrado = true;
+    assert(encontrado);
+
+    assert(Persist::deleteProjeto(prj.id));
+    ids = Persist::listarProjetos();
+    encontrado = false;
+    for (const auto& id : ids) if (id == prj.id) encontrado = true;
+    assert(!encontrado);
+}
+

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -15,6 +15,7 @@ void test_data_path();
 void test_domain_material();
 void test_material_factory();
 void test_estimador_custo();
+void test_projeto();
 
 // Executa todos os testes
 int main() {
@@ -32,5 +33,6 @@ int main() {
     test_domain_material();
     test_material_factory();
     test_estimador_custo();
+    test_projeto();
     return 0;
 }


### PR DESCRIPTION
## Summary
- adicionar entidade Projeto com itens de materiais e cortes
- permitir salvar, carregar, listar e excluir projetos em JSON
- renomear Projeto de EstimadorCusto para ProjetoCusto evitando conflitos

## Testing
- `g++ -std=c++17 -Wall src/*.cpp src/domain/*.cpp src/custo/*.cpp -Iinclude -Ithird_party -o app`
- `make -C tests`
- `./tests/run_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a2fa45ee788327856b5fadc1307968