### PR TITLE
[Projeto] feat: cálculo detalhado de custo

### DIFF
--- a/Calculadora/include/custo/CustoParams.h
+++ b/Calculadora/include/custo/CustoParams.h
@@ -4,9 +4,10 @@
 struct CustoParams {
     double perdaPadrao = 0.0;   // percentual de perda aplicado a todos os itens
     double fatorMaoObra = 0.0;  // fator multiplicador de mão de obra
+    double overhead = 0.0;      // percentual de overhead administrativo
     double markup = 0.0;        // percentual de markup/lucro
     int casasDecimais = 2;      // casas decimais do resultado
 };
 
 // Exemplo de uso:
-// CustoParams cfg{0.05, 0.1, 0.2, 2};
+// CustoParams cfg{0.05, 0.1, 0.05, 0.2, 2};

--- a/Calculadora/include/domain/Projeto.h
+++ b/Calculadora/include/domain/Projeto.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include "domain/MaterialBase.h"
+#include "custo/CustoParams.h"
 
 // Item de material dentro de um projeto
 struct ProjetoItemMaterial {
@@ -19,6 +20,18 @@ struct ProjetoItemCorte {
     double comprimento = 0.0;  // comprimento em metros
     double quantidade = 0.0;   // número de peças
     double custoUnitario = 0.0;// custo por peça
+};
+
+// Subtotal de custo para um item específico
+struct ResumoCustoItem {
+    std::string id;   // identificador do item
+    double subtotal = 0.0; // custo calculado
+};
+
+// Resumo completo de custo do projeto
+struct ResumoCustoProjeto {
+    std::vector<ResumoCustoItem> itens; // lista de subtotais
+    double total = 0.0;                 // total final com parâmetros globais
 };
 
 // Representa um projeto completo
@@ -43,5 +56,11 @@ public:
 
     // Calcula o custo total do projeto.
     double resumoCusto() const;
+
+    // Calcula custos detalhados do projeto usando EstimadorCusto.
+    // Exemplo:
+    //   CustoParams cfg{0.05, 0.1, 0.05, 0.2, 2};
+    //   auto resumo = prj.calcularCustos(cfg);
+    ResumoCustoProjeto calcularCustos(const CustoParams& params) const;
 };
 

--- a/Calculadora/src/custo/EstimadorCusto.cpp
+++ b/Calculadora/src/custo/EstimadorCusto.cpp
@@ -26,6 +26,7 @@ double EstimadorCusto::custoProjeto(const ProjetoCusto& prj, const CustoParams& 
     }
     subtotal *= (1.0 + cfg.perdaPadrao);
     subtotal *= (1.0 + cfg.fatorMaoObra);
+    subtotal *= (1.0 + cfg.overhead);
     subtotal *= (1.0 + cfg.markup);
     return arredondar(subtotal, cfg.casasDecimais);
 }

--- a/Calculadora/src/domain/Projeto.cpp
+++ b/Calculadora/src/domain/Projeto.cpp
@@ -1,6 +1,9 @@
 #include "domain/Projeto.h"
 
 #include <algorithm>
+#include <cmath>
+#include "custo/EstimadorCusto.h"
+#include "domain/MaterialUnitario.h"
 
 // Valida se medidas são estritamente positivas
 static bool medidasValidas(const Medidas& m) {
@@ -46,5 +49,48 @@ double Projeto::resumoCusto() const {
         total += c.quantidade * c.custoUnitario;
     }
     return total;
+}
+
+// Função auxiliar para arredondar valores
+static double arredondar(double valor, int casas) {
+    double fator = std::pow(10.0, casas);
+    return std::round(valor * fator) / fator;
+}
+
+// Calcula custos detalhados do projeto utilizando EstimadorCusto
+ResumoCustoProjeto Projeto::calcularCustos(const CustoParams& params) const {
+    EstimadorCusto est;
+    ResumoCustoProjeto resumo;
+    double subtotal = 0.0;
+
+    // Materiais
+    for (const auto& m : materiais) {
+        ItemReq req{m.idMaterial, "unitario", m.quantidade, m.medidas};
+        MaterialUnitario mat(m.custoUnitario);
+        double custo = est.custoMaterial(req, mat);
+        custo *= (1.0 + params.perdaPadrao);
+        resumo.itens.push_back({m.idMaterial, custo});
+        subtotal += custo;
+    }
+
+    // Cortes
+    for (const auto& c : cortes) {
+        Medidas md{c.largura, 0.0, 0.0, c.comprimento};
+        ItemReq req{c.idMaterial, "unitario", c.quantidade, md};
+        MaterialUnitario mat(c.custoUnitario);
+        double custo = est.custoMaterial(req, mat);
+        custo *= (1.0 + params.perdaPadrao);
+        resumo.itens.push_back({c.idMaterial, custo});
+        subtotal += custo;
+    }
+
+    double maoDeObra = subtotal * params.fatorMaoObra;
+    double parcial = subtotal + maoDeObra;
+    double valorOverhead = parcial * params.overhead;
+    parcial += valorOverhead;
+    double total = parcial * (1.0 + params.markup);
+    resumo.total = arredondar(total, params.casasDecimais);
+
+    return resumo;
 }
 

--- a/Calculadora/tests/estimador_custo_test.cpp
+++ b/Calculadora/tests/estimador_custo_test.cpp
@@ -33,7 +33,7 @@ void test_estimador_custo() {
     prj.materiais.push_back({reqL, &ml});
     prj.materiais.push_back({reqC, &mc});
 
-    CustoParams cfg{0.05, 0.1, 0.2, 2};
+    CustoParams cfg{0.05, 0.1, 0.0, 0.2, 2};
     double total = est.custoProjeto(prj, cfg);
     assert(total == 558.56);
 }

--- a/Calculadora/tests/projeto_custo_test.cpp
+++ b/Calculadora/tests/projeto_custo_test.cpp
@@ -1,0 +1,38 @@
+#include "domain/Projeto.h"
+#include <cassert>
+
+// Testa cálculo detalhado de custos em Projeto
+void test_projeto_custo() {
+    Projeto prj;
+    prj.id = "p1";
+    prj.nome = "Projeto 1";
+
+    ProjetoItemMaterial mat;
+    mat.idMaterial = "mat1";
+    mat.quantidade = 2.0;
+    mat.custoUnitario = 10.0;
+    mat.medidas.largura = 1.0;
+    mat.medidas.comprimento = 1.0;
+    assert(prj.adicionarMaterial(mat));
+
+    ProjetoItemCorte ct;
+    ct.idMaterial = "mat2";
+    ct.largura = 0.5;
+    ct.comprimento = 0.5;
+    ct.quantidade = 1.0;
+    ct.custoUnitario = 2.0;
+    assert(prj.adicionarCorte(ct));
+
+    CustoParams cfg;
+    cfg.perdaPadrao = 0.0;
+    cfg.fatorMaoObra = 0.1;
+    cfg.overhead = 0.05;
+    cfg.markup = 0.2;
+    cfg.casasDecimais = 2;
+
+    auto resumo = prj.calcularCustos(cfg);
+    assert(resumo.itens.size() == 2);
+    assert(resumo.itens[0].subtotal == 20.0);
+    assert(resumo.itens[1].subtotal == 2.0);
+    assert(resumo.total == 30.49);
+}

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -16,6 +16,7 @@ void test_domain_material();
 void test_material_factory();
 void test_estimador_custo();
 void test_projeto();
+void test_projeto_custo();
 
 // Executa todos os testes
 int main() {
@@ -34,5 +35,6 @@ int main() {
     test_material_factory();
     test_estimador_custo();
     test_projeto();
+    test_projeto_custo();
     return 0;
 }


### PR DESCRIPTION
## Summary
- adicionar campo de overhead em `CustoParams`
- gerar resumo de custos no `Projeto` usando `EstimadorCusto`
- cobrir cálculo detalhado com novo teste

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app`
- `make -C tests`
- `./tests/run_tests`

### 📝 Checklist deste PR
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a2ff86532083278603c0301b70be9a