### PR TITLE
[domain] feat: integrar tempos ao projeto

### DIFF
--- a/Calculadora/include/custo/CustoParams.h
+++ b/Calculadora/include/custo/CustoParams.h
@@ -3,7 +3,7 @@
 // Parâmetros globais para cálculo de custo
 struct CustoParams {
     double perdaPadrao = 0.0;   // percentual de perda aplicado a todos os itens
-    double fatorMaoObra = 0.0;  // fator multiplicador de mão de obra
+    double fatorMaoObra = 0.0;  // custo por hora de mão de obra
     double overhead = 0.0;      // percentual de overhead administrativo
     double markup = 0.0;        // percentual de markup/lucro
     int casasDecimais = 2;      // casas decimais do resultado

--- a/Calculadora/include/domain/Projeto.h
+++ b/Calculadora/include/domain/Projeto.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include "domain/MaterialBase.h"
 #include "custo/CustoParams.h"
+#include "domain/Tempo.h"
 
 // Item de material dentro de um projeto
 struct ProjetoItemMaterial {
@@ -41,6 +42,7 @@ public:
     std::string nome;               // nome do projeto
     std::vector<ProjetoItemMaterial> materiais; // itens de material
     std::vector<ProjetoItemCorte> cortes;       // itens de corte
+    std::vector<Operacao> operacoes;             // operações de mão de obra
 
     // Adiciona um material ao projeto. Retorna falso em caso de validação falha.
     // Exemplo:
@@ -62,5 +64,11 @@ public:
     //   CustoParams cfg{0.05, 0.1, 0.05, 0.2, 2};
     //   auto resumo = prj.calcularCustos(cfg);
     ResumoCustoProjeto calcularCustos(const CustoParams& params) const;
+
+    // Tempo total do projeto somando todas as operações
+    double tempoTotal() const;
+
+    // Adiciona uma operação ao projeto
+    bool adicionarOperacao(const Operacao& op);
 };
 

--- a/Calculadora/include/domain/Tempo.h
+++ b/Calculadora/include/domain/Tempo.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <nlohmann/json.hpp>
+
+// Fases básicas de uma operação
+enum class Fase {
+    Preparo,
+    Producao,
+    Finalizacao
+};
+
+// Descreve uma operação com tempo por unidade
+struct Operacao {
+    Fase fase = Fase::Preparo;  // fase da operação
+    double tempoPorUnidade = 0.0; // em horas
+    int quantidade = 0;          // número de unidades
+};
+
+namespace Tempo {
+
+// Calcula tempo total de uma operação (tempoPorUnidade * quantidade)
+double tempoItem(const Operacao& op);
+
+// Soma tempos de todas as operações do projeto
+double tempoProjeto(const std::vector<Operacao>& ops);
+
+// Converte Fase para string
+std::string faseToString(Fase f);
+
+// Converte string para Fase (default Preparo)
+Fase faseFromString(const std::string& s);
+
+} // namespace Tempo
+
+// Serialização para JSON de Operacao
+void to_json(nlohmann::json& j, const Operacao& o);
+void from_json(const nlohmann::json& j, Operacao& o);
+

--- a/Calculadora/include/persist/tempo.hpp
+++ b/Calculadora/include/persist/tempo.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "domain/Tempo.h"
+
+namespace Persist {
+
+// Carrega template de operações de data/templates/tempos/<nome>.json
+// Exemplo:
+//   std::vector<Operacao> ops;
+//   Persist::loadTempoTemplate("padrao", ops);
+bool loadTempoTemplate(const std::string& nome, std::vector<Operacao>& out);
+
+} // namespace Persist
+

--- a/Calculadora/src/domain/Projeto.cpp
+++ b/Calculadora/src/domain/Projeto.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include "custo/EstimadorCusto.h"
 #include "domain/MaterialUnitario.h"
+#include "domain/Tempo.h"
 
 // Valida se medidas são estritamente positivas
 static bool medidasValidas(const Medidas& m) {
@@ -30,6 +31,13 @@ bool Projeto::adicionarCorte(const ProjetoItemCorte& item) {
     return true;
 }
 
+bool Projeto::adicionarOperacao(const Operacao& op) {
+    if (op.tempoPorUnidade <= 0) return false;
+    if (op.quantidade <= 0) return false;
+    operacoes.push_back(op);
+    return true;
+}
+
 bool Projeto::removerItem(const std::string& idMaterial) {
     auto beforeM = materiais.size();
     materiais.erase(std::remove_if(materiais.begin(), materiais.end(), [&](const auto& m){return m.idMaterial == idMaterial;}), materiais.end());
@@ -49,6 +57,10 @@ double Projeto::resumoCusto() const {
         total += c.quantidade * c.custoUnitario;
     }
     return total;
+}
+
+double Projeto::tempoTotal() const {
+    return Tempo::tempoProjeto(operacoes);
 }
 
 // Função auxiliar para arredondar valores
@@ -84,7 +96,7 @@ ResumoCustoProjeto Projeto::calcularCustos(const CustoParams& params) const {
         subtotal += custo;
     }
 
-    double maoDeObra = subtotal * params.fatorMaoObra;
+    double maoDeObra = tempoTotal() * params.fatorMaoObra;
     double parcial = subtotal + maoDeObra;
     double valorOverhead = parcial * params.overhead;
     parcial += valorOverhead;

--- a/Calculadora/src/domain/Tempo.cpp
+++ b/Calculadora/src/domain/Tempo.cpp
@@ -1,0 +1,49 @@
+#include "domain/Tempo.h"
+
+using nlohmann::json;
+
+namespace Tempo {
+
+double tempoItem(const Operacao& op) {
+    return op.tempoPorUnidade * static_cast<double>(op.quantidade);
+}
+
+double tempoProjeto(const std::vector<Operacao>& ops) {
+    double total = 0.0;
+    for (const auto& op : ops) {
+        total += tempoItem(op);
+    }
+    return total;
+}
+
+std::string faseToString(Fase f) {
+    switch (f) {
+        case Fase::Preparo: return "preparo";
+        case Fase::Producao: return "producao";
+        case Fase::Finalizacao: return "finalizacao";
+    }
+    return "preparo";
+}
+
+Fase faseFromString(const std::string& s) {
+    if (s == "producao") return Fase::Producao;
+    if (s == "finalizacao") return Fase::Finalizacao;
+    return Fase::Preparo;
+}
+
+} // namespace Tempo
+
+void to_json(json& j, const Operacao& o) {
+    j = json{{"fase", Tempo::faseToString(o.fase)},
+             {"tempo_por_unidade", o.tempoPorUnidade},
+             {"quantidade", o.quantidade}};
+}
+
+void from_json(const json& j, Operacao& o) {
+    std::string faseStr;
+    j.at("fase").get_to(faseStr);
+    o.fase = Tempo::faseFromString(faseStr);
+    j.at("tempo_por_unidade").get_to(o.tempoPorUnidade);
+    j.at("quantidade").get_to(o.quantidade);
+}
+

--- a/Calculadora/src/persist_projeto.cpp
+++ b/Calculadora/src/persist_projeto.cpp
@@ -36,6 +36,10 @@ static json projetoToJson(const Projeto& p) {
             {"custo_unitario", c.custoUnitario}
         });
     }
+    j["operacoes"] = json::array();
+    for (const auto& op : p.operacoes) {
+        j["operacoes"].push_back(op);
+    }
     return j;
 }
 
@@ -64,6 +68,10 @@ static void jsonToProjeto(const json& j, Projeto& p) {
         jc.at("quantidade").get_to(c.quantidade);
         jc.at("custo_unitario").get_to(c.custoUnitario);
         p.cortes.push_back(c);
+    }
+    p.operacoes.clear();
+    for (const auto& jo : j.value("operacoes", json::array())) {
+        p.operacoes.push_back(jo.get<Operacao>());
     }
 }
 

--- a/Calculadora/src/persist_tempo.cpp
+++ b/Calculadora/src/persist_tempo.cpp
@@ -1,0 +1,33 @@
+#include "persist/tempo.hpp"
+#include "persist.h"
+
+#include <filesystem>
+#include <fstream>
+
+using nlohmann::json;
+namespace fs = std::filesystem;
+
+namespace Persist {
+
+bool loadTempoTemplate(const std::string& nome, std::vector<Operacao>& out) {
+    try {
+        const fs::path p = fs::path(dataPath("templates/tempos/" + nome + ".json"));
+        std::ifstream f(p);
+        if (!f) {
+            wr::p("PERSIST", p.string() + " open fail", "Red");
+            return false;
+        }
+        json j; f >> j;
+        out = j.value("operacoes", std::vector<Operacao>{});
+        return true;
+    } catch (const std::exception& e) {
+        wr::p("PERSIST", std::string("loadTempoTemplate exception: ") + e.what(), "Red");
+        return false;
+    } catch (...) {
+        wr::p("PERSIST", "loadTempoTemplate unknown exception", "Red");
+        return false;
+    }
+}
+
+} // namespace Persist
+

--- a/Calculadora/tests/Makefile
+++ b/Calculadora/tests/Makefile
@@ -6,11 +6,13 @@ TEST_SRCS = $(wildcard *.cpp)
 SRC_FILES = ../src/Material.cpp ../src/Corte.cpp ../src/cli.cpp \
             ../src/plano_corte.cpp ../src/persist.cpp \
             ../src/persist_projeto.cpp \
+            ../src/persist_tempo.cpp \
             ../src/domain/MaterialUnitario.cpp \
             ../src/domain/MaterialLinear.cpp \
             ../src/domain/MaterialCubico.cpp \
             ../src/domain/MaterialFactory.cpp \
             ../src/domain/Projeto.cpp \
+            ../src/domain/Tempo.cpp \
             ../src/custo/EstimadorCusto.cpp
 
 run_tests: $(TEST_SRCS) $(SRC_FILES)

--- a/Calculadora/tests/projeto_custo_test.cpp
+++ b/Calculadora/tests/projeto_custo_test.cpp
@@ -23,9 +23,13 @@ void test_projeto_custo() {
     ct.custoUnitario = 2.0;
     assert(prj.adicionarCorte(ct));
 
+    // Operação de 1h
+    Operacao op{Fase::Producao, 1.0, 1};
+    assert(prj.adicionarOperacao(op));
+
     CustoParams cfg;
     cfg.perdaPadrao = 0.0;
-    cfg.fatorMaoObra = 0.1;
+    cfg.fatorMaoObra = 10.0; // custo por hora
     cfg.overhead = 0.05;
     cfg.markup = 0.2;
     cfg.casasDecimais = 2;
@@ -34,5 +38,5 @@ void test_projeto_custo() {
     assert(resumo.itens.size() == 2);
     assert(resumo.itens[0].subtotal == 20.0);
     assert(resumo.itens[1].subtotal == 2.0);
-    assert(resumo.total == 30.49);
+    assert(resumo.total == 40.32);
 }

--- a/Calculadora/tests/projeto_test.cpp
+++ b/Calculadora/tests/projeto_test.cpp
@@ -33,6 +33,10 @@ void test_projeto() {
     ct.custoUnitario = 1.0;
     assert(prj.adicionarCorte(ct));
 
+    // Operação válida
+    Operacao op{Fase::Producao, 1.0, 1};
+    assert(prj.adicionarOperacao(op));
+
     // Corte inválido (medida <=0)
     ProjetoItemCorte ctInv;
     ctInv.idMaterial = "mat1";
@@ -52,12 +56,15 @@ void test_projeto() {
     // Testes de persistência
     prj.adicionarMaterial(mat);
     prj.adicionarCorte(ct);
+    prj.operacoes.clear();
+    prj.adicionarOperacao(op);
     assert(Persist::saveProjetoJSON(prj));
 
     Projeto lido;
     assert(Persist::loadProjetoJSON(prj.id, lido));
     assert(lido.materiais.size() == 1);
     assert(lido.cortes.size() == 1);
+    assert(lido.operacoes.size() == 1);
 
     auto ids = Persist::listarProjetos();
     bool encontrado = false;

--- a/Calculadora/tests/run_tests.cpp
+++ b/Calculadora/tests/run_tests.cpp
@@ -17,6 +17,7 @@ void test_material_factory();
 void test_estimador_custo();
 void test_projeto();
 void test_projeto_custo();
+void test_tempo();
 
 // Executa todos os testes
 int main() {
@@ -36,5 +37,6 @@ int main() {
     test_estimador_custo();
     test_projeto();
     test_projeto_custo();
+    test_tempo();
     return 0;
 }

--- a/Calculadora/tests/tempo_test.cpp
+++ b/Calculadora/tests/tempo_test.cpp
@@ -1,0 +1,23 @@
+#include "domain/Tempo.h"
+#include "persist/tempo.hpp"
+#include "persist.h"
+#include <cassert>
+#include <filesystem>
+
+void test_tempo() {
+    Operacao op{Fase::Preparo, 0.5, 4};
+    assert(Tempo::tempoItem(op) == 2.0);
+
+    std::vector<Operacao> ops{op};
+    assert(Tempo::tempoProjeto(ops) == 2.0);
+
+    // Teste de template
+    nlohmann::json j;
+    j["operacoes"] = ops;
+    auto path = Persist::dataPath("templates/tempos/teste.json");
+    Persist::atomicWrite(std::filesystem::path(path), j.dump());
+    std::vector<Operacao> carregadas;
+    assert(Persist::loadTempoTemplate("teste", carregadas));
+    assert(carregadas.size() == 1);
+    assert(Tempo::tempoProjeto(carregadas) == 2.0);
+}


### PR DESCRIPTION
## Summary
- add Tempo domain with Fase e Operacao
- carregar templates de tempo via persistência
- integrar tempo de operações ao Projeto e ao custo de mão de obra

## Testing
- `g++ -std=c++17 -Wall src/*.cpp src/domain/*.cpp src/custo/*.cpp -Iinclude -Ithird_party -o app`
- `make -C tests`
- `./tests/run_tests`

### Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a3016e1b8c8327b3ba14ae129af543