### PR TITLE
[cli] feat: adicionar subcomandos e flags

### DIFF
--- a/Calculadora/include/cli.h
+++ b/Calculadora/include/cli.h
@@ -4,19 +4,23 @@
 // Estruturas e funções para argumentos de linha de comando
 // ----------------------------------------------------------
 #include <string>
+#include <vector>
 
 // Comandos reconhecidos pela aplicação (ainda não implementados)
 enum class Comando {
     Nenhum,   // nenhum comando informado
-    Abrir,    // abrir projeto existente
+    Criar,    // criar recursos
     Listar,   // listar recursos
     Comparar  // comparar dados
 };
 
 struct CliOptions {
-    bool showHelp = false; // exibir ajuda
-    bool autoMode = false; // modo automático
-    std::string projeto;   // caminho para o projeto
+    bool showHelp = false;       // exibir ajuda
+    bool autoMode = false;       // modo automático
+    std::string projeto;         // caminho para o projeto
+    std::string tipo;            // tipo de material
+    std::string ordem;           // ordem de listagem
+    std::vector<int> ids;        // ids informados para comparação
     Comando comando = Comando::Nenhum; // comando solicitado
 };
 

--- a/Calculadora/src/cli.cpp
+++ b/Calculadora/src/cli.cpp
@@ -5,6 +5,7 @@
 
 #include "cli.h"
 #include <string>
+#include <sstream>
 
 CliOptions parseArgs(int argc, char* argv[]) {
     CliOptions opt; // guarda opções reconhecidas
@@ -17,10 +18,45 @@ CliOptions parseArgs(int argc, char* argv[]) {
         } else if (a == "--projeto" && i + 1 < argc) {
             // consome próximo argumento como caminho do projeto
             opt.projeto = argv[++i];
+        } else if (a.rfind("--tipo", 0) == 0) {
+            // aceita --tipo=valor ou --tipo valor
+            std::string valor;
+            if (a == "--tipo" && i + 1 < argc) {
+                valor = argv[++i];
+            } else if (a.find('=') != std::string::npos) {
+                valor = a.substr(a.find('=') + 1);
+            }
+            if (!valor.empty()) opt.tipo = valor;
+        } else if (a.rfind("--ordem", 0) == 0) {
+            // aceita --ordem=campo:direcao ou --ordem valor
+            std::string valor;
+            if (a == "--ordem" && i + 1 < argc) {
+                valor = argv[++i];
+            } else if (a.find('=') != std::string::npos) {
+                valor = a.substr(a.find('=') + 1);
+            }
+            if (!valor.empty()) opt.ordem = valor;
+        } else if (a.rfind("--ids", 0) == 0) {
+            // aceita lista separada por vírgula
+            std::string valor;
+            if (a == "--ids" && i + 1 < argc) {
+                valor = argv[++i];
+            } else if (a.find('=') != std::string::npos) {
+                valor = a.substr(a.find('=') + 1);
+            }
+            if (!valor.empty()) {
+                std::stringstream ss(valor);
+                std::string item;
+                while (std::getline(ss, item, ',')) {
+                    if (!item.empty()) {
+                        opt.ids.push_back(std::stoi(item));
+                    }
+                }
+            }
         } else if (opt.comando == Comando::Nenhum) {
             // registra comando principal
-            if (a == "abrir") {
-                opt.comando = Comando::Abrir;
+            if (a == "criar") {
+                opt.comando = Comando::Criar;
             } else if (a == "listar") {
                 opt.comando = Comando::Listar;
             } else if (a == "comparar") {

--- a/Calculadora/src/main.cpp
+++ b/Calculadora/src/main.cpp
@@ -23,9 +23,12 @@ int main(int argc, char* argv[]) {
     // Se for solicitado help, exibe instruções e sai
     if (opt.showHelp) {
         std::cout << "Uso: ./app [comando] [opcoes]\n";
-        std::cout << "  comandos: abrir, listar, comparar (em construcao)\n";
+        std::cout << "  comandos: criar, listar, comparar (em construcao)\n";
         std::cout << "  --auto : calcula usando o material mais barato.\n";
         std::cout << "  --projeto <arq> : abre projeto informado.\n";
+        std::cout << "  --tipo <t> : filtra por tipo de material.\n";
+        std::cout << "  --ordem <c:d> : ordena listagem.\n";
+        std::cout << "  --ids <1,2,3> : ids para comparacao.\n";
         std::cout << "  --help : mostra esta ajuda e finaliza.\n";
         return 0;
     }
@@ -34,7 +37,7 @@ int main(int argc, char* argv[]) {
     if (opt.comando != Comando::Nenhum) {
         std::string nome;
         switch (opt.comando) {
-            case Comando::Abrir: nome = "abrir"; break;
+            case Comando::Criar: nome = "criar"; break;
             case Comando::Listar: nome = "listar"; break;
             case Comando::Comparar: nome = "comparar"; break;
             default: nome = ""; break;

--- a/Calculadora/tests/cli_test.cpp
+++ b/Calculadora/tests/cli_test.cpp
@@ -21,9 +21,9 @@ void test_cli() {
     assert(o3.projeto == "proj.json");
 
     // testa comandos
-    const char* a4[] = {"app", "abrir"};
+    const char* a4[] = {"app", "criar"};
     CliOptions o4 = parseArgs(2, const_cast<char**>(a4));
-    assert(o4.comando == Comando::Abrir);
+    assert(o4.comando == Comando::Criar);
 
     const char* a5[] = {"app", "listar"};
     CliOptions o5 = parseArgs(2, const_cast<char**>(a5));
@@ -32,4 +32,18 @@ void test_cli() {
     const char* a6[] = {"app", "comparar"};
     CliOptions o6 = parseArgs(2, const_cast<char**>(a6));
     assert(o6.comando == Comando::Comparar);
+
+    // testa flags extras
+    const char* a7[] = {"app", "--tipo", "linear"};
+    CliOptions o7 = parseArgs(3, const_cast<char**>(a7));
+    assert(o7.tipo == "linear");
+
+    const char* a8[] = {"app", "--ordem=preco:asc"};
+    CliOptions o8 = parseArgs(2, const_cast<char**>(a8));
+    assert(o8.ordem == "preco:asc");
+
+    const char* a9[] = {"app", "--ids", "1,3,5"};
+    CliOptions o9 = parseArgs(3, const_cast<char**>(a9));
+    assert(o9.ids.size() == 3);
+    assert(o9.ids[0] == 1 && o9.ids[1] == 3 && o9.ids[2] == 5);
 }


### PR DESCRIPTION
## Summary
- adicionar suporte aos subcomandos criar/listar/comparar
- parsear flags `--tipo`, `--ordem` e `--ids`
- atualizar ajuda da CLI e cobrir novos casos de teste

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app` *(fails: undefined reference to `ui::renderBreadcrumb`...)*
- `make -C tests`
- `./tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_68a324c211848327af634d1c45f676a6