### PR TITLE
docs: expand CLI and data format guides

### DIFF
--- a/docs/CUSTO.md
+++ b/docs/CUSTO.md
@@ -1,0 +1,15 @@
+# Cálculo de Custos
+
+Fórmulas utilizadas pela calculadora para estimar despesas.
+
+## Fórmulas básicas
+
+- **Unitário:** `custo = preco_unitario * quantidade`
+- **Linear:** `custo = preco_metro * comprimento`
+- **Cúbico:** `custo = preco_m3 * (largura * altura * profundidade)`
+
+## Navegação
+
+Os valores podem ser consultados em:
+
+- Menu Principal > Relatórios > Custos

--- a/docs/MATERIAIS.md
+++ b/docs/MATERIAIS.md
@@ -1,0 +1,20 @@
+# Materiais
+
+Visão geral dos tipos de materiais suportados pela calculadora e como os custos são estimados.
+
+## Tipos
+
+- **Unitário** – itens contados em peças individuais.
+- **Linear** – materiais comercializados por metro.
+- **Cúbico** – produtos vendidos por volume (m³).
+
+## Fórmulas
+
+- Unitário: `custo_total = preco_unitario * quantidade`
+- Linear: `custo_total = preco_metro * comprimento`
+- Cúbico: `custo_total = preco_m3 * largura * altura * profundidade`
+
+## Navegação
+
+- Menu Principal > Materiais > Listar
+- Menu Principal > Materiais > Criar

--- a/docs/MENU.md
+++ b/docs/MENU.md
@@ -1,0 +1,17 @@
+# Menu e Navegação
+
+Estrutura de menus disponível na linha de comando.
+
+## Menu Principal
+
+- **Materiais**
+  - Listar
+  - Criar
+- **Projetos**
+  - Abrir
+  - Listar
+- **Relatórios**
+  - Custos
+  - Tempos
+
+A navegação é realizada por meio de subcomandos, por exemplo `./app listar` ou `./app comparar --ids=1,2`.

--- a/docs/PROJETOS.md
+++ b/docs/PROJETOS.md
@@ -1,0 +1,22 @@
+# Projetos
+
+Estrutura básica para armazenar projetos de corte.
+
+## Exemplo JSON
+
+```json
+{
+  "id": "p1",
+  "nome": "protótipo",
+  "materiais": [
+    {"id": "m1", "quantidade": 2}
+  ]
+}
+```
+
+## Exemplo CSV
+
+```
+id,nome,material,quantidade
+p1,protótipo,m1,2
+```

--- a/docs/RELATORIOS.md
+++ b/docs/RELATORIOS.md
@@ -1,0 +1,20 @@
+# Relatórios
+
+Dados consolidados com informações de projetos e execuções.
+
+## Exemplo JSON
+
+```json
+{
+  "projeto": "p1",
+  "custo_total": 100.0,
+  "itens": 3
+}
+```
+
+## Exemplo CSV
+
+```
+projeto,custo_total,itens
+p1,100.0,3
+```

--- a/docs/TEMPOS.md
+++ b/docs/TEMPOS.md
@@ -1,0 +1,19 @@
+# Tempos
+
+Exemplos de registro de durações de execução.
+
+## Exemplo JSON
+
+```json
+{
+  "etapa": "corte",
+  "duracao_ms": 1200
+}
+```
+
+## Exemplo CSV
+
+```
+etapa,duracao_ms
+corte,1200
+```

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -19,6 +19,25 @@ Carrega o projeto informado para uso na sessão (em desenvolvimento).
 
 As opções podem ser combinadas conforme necessário.
 
+## Subcomandos
+
+Além das opções, é possível utilizar subcomandos para manipular dados persistidos:
+
+```bash
+./app criar
+```
+Cria um novo recurso (em desenvolvimento).
+
+```bash
+./app listar --tipo=linear --ordem=preco:asc
+```
+Lista materiais filtrando por tipo e ordenação.
+
+```bash
+./app comparar --ids=1,2,3
+```
+Compara materiais pelos IDs informados.
+
 ## Configuração do VS Code
 
 Execute `start.bat` para gerar os arquivos de configuração do VS Code.


### PR DESCRIPTION
## Summary
- document material types, cost formulas and menu navigation
- add guides for tempos, projetos and relatorios with JSON/CSV examples
- describe new CLI subcommands in usage docs

## Testing
- `make -C Calculadora`

------
https://chatgpt.com/codex/tasks/task_e_68a330dd9e1c83278f07e07f4136562a