### PR TITLE
feat: make persistence base directory configurable

### DIFF
--- a/Calculadora/tests/data_path_test.cpp
+++ b/Calculadora/tests/data_path_test.cpp
@@ -1,10 +1,26 @@
 #include <cassert>
 #include <filesystem>
 #include "core/persist.h"
+#include <cstdlib>
 
-// Testa que dataPath cria o diretório `data` e retorna o caminho correto
+// Testa dataPath com diretório padrão, ambiente e parâmetro explícito
 void test_data_path() {
+    // Uso de struct de configuração
+    Persist::Config cfg; cfg.baseDir = "tmpdata";
+    Persist::setConfig(cfg);
     const std::string p = Persist::dataPath("dummy.txt");
-    assert(p == "data/dummy.txt");
-    assert(std::filesystem::exists("data"));
+    assert(p == "tmpdata/dummy.txt");
+    assert(std::filesystem::exists("tmpdata"));
+
+    // Uso de variável de ambiente
+    setenv("PERSIST_BASE_DIR", "envdata", 1);
+    Persist::setConfig(Persist::Config::fromEnv());
+    const std::string p2 = Persist::dataPath("dummy2.txt");
+    assert(p2 == "envdata/dummy2.txt");
+    assert(std::filesystem::exists("envdata"));
+
+    // Parâmetro explícito
+    const std::string p3 = Persist::dataPath("dummy3.txt", "paramdata");
+    assert(p3 == "paramdata/dummy3.txt");
+    assert(std::filesystem::exists("paramdata"));
 }


### PR DESCRIPTION
## Summary
- allow overriding persistence base directory via Config struct or `PERSIST_BASE_DIR`
- add optional base path parameter to `Persist::dataPath` and I/O helpers
- test configurable dataPath through struct, env var, and explicit argument

## Testing
- `cd Calculadora/tests && make clean && make run_tests`
- `cd Calculadora && tests/run_tests`


------
https://chatgpt.com/codex/tasks/task_e_68a396fa7df88327a6f97909d60fef30