### PR TITLE
[DUKE] feat: rename calculadora namespace to duke

### DIFF
--- a/DUKE/README.md
+++ b/DUKE/README.md
@@ -4,12 +4,12 @@ API pública simplificada para cálculos de cortes.
 
 ## Uso
 
-Inclua `include/calculadora.hpp` e utilize as funções disponibilizadas.
+Inclua `include/duke.hpp` e utilize as funções disponibilizadas.
 
 ```cpp
-#include "calculadora.hpp"
+#include "duke.hpp"
 
-using namespace calculadora;
+using namespace duke;
 
 int main() {
     Material m{"Madeira", 100.0, 2.0, 2.0};

--- a/DUKE/include/Corte.h
+++ b/DUKE/include/Corte.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-namespace calculadora {
+namespace duke {
 
 class Corte {
 private:
@@ -21,4 +21,4 @@ public:
     void imprimir() const;
 };
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/Material.h
+++ b/DUKE/include/Material.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-namespace calculadora {
+namespace duke {
 
 class Material {
 private:
@@ -33,4 +33,4 @@ public:
     void mostrar() const;
 };
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/cli/App.h
+++ b/DUKE/include/cli/App.h
@@ -5,7 +5,7 @@
 #include "core/persist.h"
 #include "Material.h"
 #include "core.h"
-namespace calculadora {
+namespace duke {
 
 class App {
 private:
@@ -33,4 +33,4 @@ public:
     void iniciar(bool autoMode = false);     // implementado em App.cpp
 };
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/cli/args.h
+++ b/DUKE/include/cli/args.h
@@ -5,7 +5,7 @@
 // ----------------------------------------------------------
 #include <string>
 #include <vector>
-namespace calculadora {
+namespace duke {
 
 // Comandos reconhecidos pela aplicação (ainda não implementados)
 enum class Comando {
@@ -30,4 +30,4 @@ struct CliOptions {
 //   CliOptions opt = parseArgs(argc, argv);
 CliOptions parseArgs(int argc, char* argv[]);
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/core.h
+++ b/DUKE/include/core.h
@@ -4,7 +4,7 @@
 #include <string>
 #include "Material.h"
 #include "core/persist.h"
-namespace calculadora {
+namespace duke {
 
 namespace core {
     // Base de comparação com nome e valor
@@ -34,4 +34,4 @@ namespace core {
     Como extremosPorM2(const std::vector<Material>& mats);
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/custo/CustoParams.h
+++ b/DUKE/include/custo/CustoParams.h
@@ -1,4 +1,4 @@
-namespace calculadora {
+namespace duke {
 #pragma once
 
 // Parâmetros globais para cálculo de custo
@@ -12,4 +12,4 @@ struct CustoParams {
 
 // Exemplo de uso:
 // CustoParams cfg{0.05, 0.1, 0.05, 0.2, 2};
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/custo/EstimadorCusto.h
+++ b/DUKE/include/custo/EstimadorCusto.h
@@ -5,7 +5,7 @@
 
 #include "custo/CustoParams.h"
 #include "domain/MaterialBase.h"
-namespace calculadora {
+namespace duke {
 
 // Item requisitado com identificação e medidas
 struct ItemReq {
@@ -48,4 +48,4 @@ public:
     double custoProjeto(const ProjetoCusto& prj, const CustoParams& cfg) const;
 };
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/domain/MaterialBase.h
+++ b/DUKE/include/domain/MaterialBase.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-namespace calculadora {
+namespace duke {
 
 // Estrutura com medidas de um item
 struct Medidas {
@@ -22,4 +22,4 @@ public:
     // Calcula o custo total dado uma quantidade e medidas
     virtual double custo(double qtd, const Medidas& m) const = 0;
 };
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/domain/MaterialCubico.h
+++ b/DUKE/include/domain/MaterialCubico.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "domain/MaterialBase.h"
-namespace calculadora {
+namespace duke {
 
 // Material vendido por metro cúbico
 class MaterialCubico : public MaterialBase {
@@ -13,4 +13,4 @@ public:
     std::string tipo() const override;
     double custo(double qtd, const Medidas& m) const override;
 };
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/domain/MaterialFactory.h
+++ b/DUKE/include/domain/MaterialFactory.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include "domain/MaterialBase.h"
 #include "core/persist.h"
-namespace calculadora {
+namespace duke {
 
 // Factory para criar materiais a partir de um MaterialDTO
 class MaterialFactory {
@@ -14,4 +14,4 @@ public:
     //   auto mat = MaterialFactory::fromDTO(d);
     static std::unique_ptr<MaterialBase> fromDTO(const MaterialDTO& dto);
 };
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/domain/MaterialLinear.h
+++ b/DUKE/include/domain/MaterialLinear.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "domain/MaterialBase.h"
-namespace calculadora {
+namespace duke {
 
 // Material vendido por metro linear
 class MaterialLinear : public MaterialBase {
@@ -14,4 +14,4 @@ public:
     std::string tipo() const override;
     double custo(double qtd, const Medidas& m) const override;
 };
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/domain/MaterialUnitario.h
+++ b/DUKE/include/domain/MaterialUnitario.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "domain/MaterialBase.h"
-namespace calculadora {
+namespace duke {
 
 // Material vendido por unidade
 class MaterialUnitario : public MaterialBase {
@@ -13,4 +13,4 @@ public:
     std::string tipo() const override;
     double custo(double qtd, const Medidas& m) const override;
 };
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/domain/Projeto.h
+++ b/DUKE/include/domain/Projeto.h
@@ -5,7 +5,7 @@
 #include "domain/MaterialBase.h"
 #include "custo/CustoParams.h"
 #include "domain/Tempo.h"
-namespace calculadora {
+namespace duke {
 
 // Item de material dentro de um projeto
 struct ProjetoItemMaterial {
@@ -73,4 +73,4 @@ public:
     bool adicionarOperacao(const Operacao& op);
 };
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/domain/Tempo.h
+++ b/DUKE/include/domain/Tempo.h
@@ -3,7 +3,7 @@
 #include <vector>
 #include <string>
 #include <nlohmann/json.hpp>
-namespace calculadora {
+namespace duke {
 
 // Fases básicas de uma operação
 enum class Fase {
@@ -39,4 +39,4 @@ Fase faseFromString(const std::string& s);
 void to_json(nlohmann::json& j, const Operacao& o);
 void from_json(const nlohmann::json& j, Operacao& o);
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/duke.hpp
+++ b/DUKE/include/duke.hpp
@@ -2,7 +2,7 @@
 
 #include "Material.h"
 
-namespace calculadora {
+namespace duke {
 
 /**
  * @brief Calcula o valor de um corte retangular.
@@ -25,5 +25,5 @@ double calcularValorCorte(const Material& material,
                           double largura,
                           double comprimento);
 
-} // namespace calculadora
+} // namespace duke
 

--- a/DUKE/include/persist.hpp
+++ b/DUKE/include/persist.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include "plano_corte.h"
-namespace calculadora {
+namespace duke {
 
 namespace Persist {
 
@@ -81,4 +81,4 @@ bool loadIndex(std::vector<PlanoIndexEntry>& out);
 
 } // namespace Persist
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/persist/projeto.hpp
+++ b/DUKE/include/persist/projeto.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include "domain/Projeto.h"
-namespace calculadora {
+namespace duke {
 
 namespace Persist {
 
@@ -21,4 +21,4 @@ bool deleteProjeto(const std::string& id);
 
 } // namespace Persist
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/persist/tempo.hpp
+++ b/DUKE/include/persist/tempo.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include "domain/Tempo.h"
-namespace calculadora {
+namespace duke {
 
 namespace Persist {
 
@@ -15,4 +15,4 @@ bool loadTempoTemplate(const std::string& nome, std::vector<Operacao>& out);
 
 } // namespace Persist
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/plano_corte.h
+++ b/DUKE/include/plano_corte.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include <nlohmann/json.hpp>
-namespace calculadora {
+namespace duke {
 
 using nlohmann::json;
 
@@ -37,4 +37,4 @@ void from_json(const json& j, CorteDTO& c);
 void to_json(json& j, const PlanoCorteDTO& p);
 void from_json(const json& j, PlanoCorteDTO& p);
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/ui/Menu.h
+++ b/DUKE/include/ui/Menu.h
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 #include <iostream>
-namespace calculadora {
+namespace duke {
 
 namespace ui {
 
@@ -57,4 +57,4 @@ std::string readString(const std::string& prompt,
 
 } // namespace ui
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/include/ui/Screens.h
+++ b/DUKE/include/ui/Screens.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <string>
-namespace calculadora {
+namespace duke {
 
 namespace ui {
 
@@ -27,4 +27,4 @@ inline std::string toString(MenuState s) {
 
 } // namespace ui
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/Corte.cpp
+++ b/DUKE/src/Corte.cpp
@@ -2,7 +2,7 @@
 #include "core/format.h"
 #include <algorithm>
 #include <iostream>
-namespace calculadora {
+namespace duke {
 
 Corte::Corte(const std::string& n, double l, double c, double precoPorM2)
     : nome(n),
@@ -25,4 +25,4 @@ void Corte::imprimir() const {
               << "Valor        : " << UN_MONE << valor << "\n";
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/Material.cpp
+++ b/DUKE/src/Material.cpp
@@ -1,7 +1,7 @@
 #include "Material.h"
 #include "core/format.h"
 #include <iostream>
-namespace calculadora {
+namespace duke {
 
 void Material::iniciar() noexcept {
     area = largura * comprimento;
@@ -36,4 +36,4 @@ void Material::mostrar() const {
               << "Valor por m2  : " << UN_MONE << capPorm2() << "\n\n";
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/calculadora.cpp
+++ b/DUKE/src/calculadora.cpp
@@ -1,6 +1,6 @@
-#include "calculadora.hpp"
+#include "duke.hpp"
 
-namespace calculadora {
+namespace duke {
 
 double calcularValorCorte(const Material& material,
                           double largura,
@@ -9,5 +9,5 @@ double calcularValorCorte(const Material& material,
     return area * material.capPorm2();
 }
 
-} // namespace calculadora
+} // namespace duke
 

--- a/DUKE/src/cli/app.cpp
+++ b/DUKE/src/cli/app.cpp
@@ -22,7 +22,7 @@
 #include "ui/Menu.h"
 #include "ui/Screens.h"
 #include "core.h"
-namespace calculadora {
+namespace duke {
 
 // ------------------------------------------------------------
 // Helpers apenas visíveis neste arquivo
@@ -502,4 +502,4 @@ void App::iniciar(bool autoMode) {
     std::cout << "\n";
     wr::p("APP", "Finalizando..", "Green");
 }
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/cli/args.cpp
+++ b/DUKE/src/cli/args.cpp
@@ -6,7 +6,7 @@
 #include "cli/args.h"
 #include <string>
 #include <sstream>
-namespace calculadora {
+namespace duke {
 
 CliOptions parseArgs(int argc, char* argv[]) {
     CliOptions opt; // guarda opções reconhecidas
@@ -68,4 +68,4 @@ CliOptions parseArgs(int argc, char* argv[]) {
     return opt;
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/core.cpp
+++ b/DUKE/src/core.cpp
@@ -1,6 +1,6 @@
 #include "core.h"
 #include <algorithm>
-namespace calculadora {
+namespace duke {
 
 namespace core {
     std::vector<Material> reconstruirMateriais(const std::vector<MaterialDTO>& v) {
@@ -19,4 +19,4 @@ namespace core {
     }
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/custo/EstimadorCusto.cpp
+++ b/DUKE/src/custo/EstimadorCusto.cpp
@@ -1,7 +1,7 @@
 #include "custo/EstimadorCusto.h"
 
 #include <cmath>
-namespace calculadora {
+namespace duke {
 
 // Calcula o custo de um material específico
 // Exemplo: ItemReq req{...}; MaterialUnitario m(5.0);
@@ -32,4 +32,4 @@ double EstimadorCusto::custoProjeto(const ProjetoCusto& prj, const CustoParams& 
     return arredondar(subtotal, cfg.casasDecimais);
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/domain/MaterialCubico.cpp
+++ b/DUKE/src/domain/MaterialCubico.cpp
@@ -1,5 +1,5 @@
 #include "domain/MaterialCubico.h"
-namespace calculadora {
+namespace duke {
 
 // Construtor com preco por metro cubico
 // Exemplo: MaterialCubico mc(100.0);
@@ -16,4 +16,4 @@ double MaterialCubico::custo(double qtd, const Medidas& m) const {
     double volume = m.largura * m.altura * m.profundidade;
     return precoM3 * volume * qtd;
 }
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/domain/MaterialFactory.cpp
+++ b/DUKE/src/domain/MaterialFactory.cpp
@@ -3,7 +3,7 @@
 #include "domain/MaterialLinear.h"
 #include "domain/MaterialCubico.h"
 #include <stdexcept>
-namespace calculadora {
+namespace duke {
 
 // Cria instância concreta conforme o tipo informado
 // Exemplo: fromDTO({"Item",10,0,0,"unitario"}) -> MaterialUnitario
@@ -19,4 +19,4 @@ std::unique_ptr<MaterialBase> MaterialFactory::fromDTO(const MaterialDTO& dto) {
     }
     throw std::invalid_argument("tipo desconhecido: " + dto.tipo);
 }
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/domain/MaterialLinear.cpp
+++ b/DUKE/src/domain/MaterialLinear.cpp
@@ -1,5 +1,5 @@
 #include "domain/MaterialLinear.h"
-namespace calculadora {
+namespace duke {
 
 // Construtor com preco por metro e percentual de perda
 // Exemplo: MaterialLinear ml(10.0, 0.1);
@@ -16,4 +16,4 @@ double MaterialLinear::custo(double qtd, const Medidas& m) const {
     double metros = m.comprimento;
     return precoM * metros * qtd * (1.0 + perda);
 }
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/domain/MaterialUnitario.cpp
+++ b/DUKE/src/domain/MaterialUnitario.cpp
@@ -1,5 +1,5 @@
 #include "domain/MaterialUnitario.h"
-namespace calculadora {
+namespace duke {
 
 // Construtor com preco por unidade
 // Exemplo: MaterialUnitario mu(5.0);
@@ -15,4 +15,4 @@ std::string MaterialUnitario::tipo() const { return "unitario"; }
 double MaterialUnitario::custo(double qtd, const Medidas&) const {
     return precoUnitario * qtd;
 }
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/domain/Projeto.cpp
+++ b/DUKE/src/domain/Projeto.cpp
@@ -5,7 +5,7 @@
 #include "custo/EstimadorCusto.h"
 #include "domain/MaterialUnitario.h"
 #include "domain/Tempo.h"
-namespace calculadora {
+namespace duke {
 
 // Valida se medidas são estritamente positivas
 static bool medidasValidas(const Medidas& m) {
@@ -107,4 +107,4 @@ ResumoCustoProjeto Projeto::calcularCustos(const CustoParams& params) const {
     return resumo;
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/domain/Tempo.cpp
+++ b/DUKE/src/domain/Tempo.cpp
@@ -1,5 +1,5 @@
 #include "domain/Tempo.h"
-namespace calculadora {
+namespace duke {
 
 using nlohmann::json;
 
@@ -48,4 +48,4 @@ void from_json(const json& j, Operacao& o) {
     j.at("quantidade").get_to(o.quantidade);
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/main.cpp
+++ b/DUKE/src/main.cpp
@@ -8,7 +8,7 @@
 #include "cli/args.h"
 #include <string>
 
-using namespace calculadora;
+using namespace duke;
 
 // ----------------------------------------------------------
 // Entrada principal da aplicação

--- a/DUKE/src/persist.cpp
+++ b/DUKE/src/persist.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <fstream>
 #include <system_error>
-namespace calculadora {
+namespace duke {
 
 namespace fs = std::filesystem;
 
@@ -210,4 +210,4 @@ bool loadIndex(std::vector<PlanoIndexEntry>& out) {
 
 } // namespace Persist
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/persist_projeto.cpp
+++ b/DUKE/src/persist_projeto.cpp
@@ -3,7 +3,7 @@
 
 #include <filesystem>
 #include <fstream>
-namespace calculadora {
+namespace duke {
 
 using nlohmann::json;
 namespace fs = std::filesystem;
@@ -188,4 +188,4 @@ bool Persist::deleteProjeto(const std::string& id) {
     return ok;
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/persist_tempo.cpp
+++ b/DUKE/src/persist_tempo.cpp
@@ -3,7 +3,7 @@
 
 #include <filesystem>
 #include <fstream>
-namespace calculadora {
+namespace duke {
 
 using nlohmann::json;
 namespace fs = std::filesystem;
@@ -50,4 +50,4 @@ bool loadTempoTemplate(const std::string& nome, std::vector<Operacao>& out) {
 
 } // namespace Persist
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/plano_corte.cpp
+++ b/DUKE/src/plano_corte.cpp
@@ -1,5 +1,5 @@
 #include "plano_corte.h"
-namespace calculadora {
+namespace duke {
 
 // Serializa um CorteDTO para JSON
 void to_json(json& j, const CorteDTO& c) {
@@ -51,4 +51,4 @@ void from_json(const json& j, PlanoCorteDTO& p) {
     if (j.contains("total_valor")) j.at("total_valor").get_to(p.total_valor);
 }
 
-} // namespace calculadora
+} // namespace duke

--- a/DUKE/src/ui/Menu.cpp
+++ b/DUKE/src/ui/Menu.cpp
@@ -1,7 +1,7 @@
 #include "ui/Menu.h"
 #include <limits>
 #include <cctype>
-namespace calculadora {
+namespace duke {
 
 namespace ui {
 
@@ -104,4 +104,4 @@ std::string readString(const std::string& prompt,
 
 } // namespace ui
 
-} // namespace calculadora
+} // namespace duke

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -6,7 +6,7 @@ Visão geral dos principais componentes do DUKE.
 Responsável pela lógica de comparação e pelos cálculos de cortes e materiais.
 Principais arquivos:
 - `DUKE/app.cpp`
-- `DUKE/include/calculadora.hpp`
+- `DUKE/include/duke.hpp`
 
 ## Persistência de dados
 Centraliza leitura e escrita de informações em JSON ou CSV, além das

--- a/docs/REVISIONS.md
+++ b/docs/REVISIONS.md
@@ -2,7 +2,7 @@
 
 1. Separar a lógica do app em módulos
    - Motivação: Facilitar manutenção, testes e reutilização.
-   - Arquivos impactados: `DUKE/app.cpp`, `DUKE/include/calculadora.hpp`, `DUKE/main.cpp`.
+   - Arquivos impactados: `DUKE/app.cpp`, `DUKE/include/duke.hpp`, `DUKE/main.cpp`.
 
 2. Validar dados antes de salvar
    - Motivação: Garantir integridade das informações e evitar erros ao persistir dados.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,5 +43,5 @@ Com a evolução recente, a camada de persistência agora:
 - Documentação expandida em `docs/` para cobrir uso e desenvolvimento.
 - Guia de contribuições explicando estilo e práticas de codificação.
 - Centralizar constantes de formatação em `format.h` para reutilização.
-- API pública simplificada via `calculadora.hpp`. ✅
+- API pública simplificada via `duke.hpp`. ✅
 

--- a/tests/calculadora/calculadora_api_test.cpp
+++ b/tests/calculadora/calculadora_api_test.cpp
@@ -1,4 +1,4 @@
-#include "calculadora.hpp"
+#include "duke.hpp"
 #include <cassert>
 
 // Testa cálculo simplificado do valor de corte

--- a/tests/calculadora/namespace.h
+++ b/tests/calculadora/namespace.h
@@ -1,3 +1,3 @@
 #pragma once
-namespace calculadora {}
-using namespace calculadora;
+namespace duke {}
+using namespace duke;

--- a/tests/calculadora/tempo_test.cpp
+++ b/tests/calculadora/tempo_test.cpp
@@ -17,7 +17,7 @@ void test_tempo() {
     auto path = ::Persist::dataPath("templates/tempos/teste.json");
     ::Persist::atomicWrite(std::filesystem::path(path), j.dump());
     std::vector<Operacao> carregadas;
-    assert(calculadora::Persist::loadTempoTemplate("teste", carregadas));
+    assert(duke::Persist::loadTempoTemplate("teste", carregadas));
     assert(carregadas.size() == 1);
     assert(Tempo::tempoProjeto(carregadas) == 2.0);
 }


### PR DESCRIPTION
## Summary
- rename public header to `duke.hpp`
- switch all sources and tests to `namespace duke`
- update includes and using statements

## Testing
- ⚠️ `make tests` (missing tests directory)
- ✅ `make -C tests`

### 📝 Checklist deste PR
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a3acff234483278920c23f50116b72