### PR TITLE
[cli] feat: modulariza parser, comandos e utilidades

### DIFF
--- a/DUKE/Makefile
+++ b/DUKE/Makefile
@@ -5,7 +5,8 @@ INCLUDES = -Iinclude -Ithird_party -I$(CORE_DIR)/include
 
 CORE_LIB = $(CORE_DIR)/libcore.a
 
-SRC := $(wildcard src/*.cpp) $(wildcard src/cli/*.cpp) \
+CLI_SRC := src/cli/app.cpp src/cli/args.cpp src/cli/parser.cpp src/cli/utils.cpp src/cli/commands.cpp
+SRC := $(wildcard src/*.cpp) $(CLI_SRC) \
        $(wildcard src/domain/*.cpp) $(wildcard src/custo/*.cpp) \
        $(wildcard src/ui/*.cpp)
 LIB_SRC := $(filter-out src/main.cpp,$(SRC))

--- a/DUKE/include/cli/commands.h
+++ b/DUKE/include/cli/commands.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+#include "cli/utils.h"
+
+namespace duke::cli {
+
+// Adiciona novo material
+// Exemplo:
+//   duke::cli::adicionarMaterial(base, mats);
+void adicionarMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats);
+
+// Edita material existente
+// Exemplo:
+//   duke::cli::editarMaterial(base, mats);
+void editarMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats);
+
+// Remove material por indice
+// Exemplo:
+//   duke::cli::removerMaterial(base, mats);
+void removerMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats);
+
+} // namespace duke::cli
+

--- a/DUKE/include/cli/parser.h
+++ b/DUKE/include/cli/parser.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace duke::cli {
+
+// Lê uma opção do usuário garantindo apenas 1 ou 2
+// Exemplo:
+//   int opt = duke::cli::lerOpcao12();
+int lerOpcao12(int padrao = 1);
+
+} // namespace duke::cli
+

--- a/DUKE/include/cli/utils.h
+++ b/DUKE/include/cli/utils.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <vector>
+#include "core.h"
+#include "persist.hpp"
+
+namespace duke::cli {
+
+// Exibe materiais cadastrados
+// Exemplo:
+//   duke::cli::listarMateriais(base);
+void listarMateriais(const std::vector<MaterialDTO>& base);
+
+// Reconstrói vetor de Materiais e persiste base
+// Exemplo:
+//   duke::cli::salvarReconstruir(base, mats);
+void salvarReconstruir(std::vector<MaterialDTO>& base, std::vector<Material>& mats);
+
+} // namespace duke::cli
+

--- a/DUKE/src/cli/commands.cpp
+++ b/DUKE/src/cli/commands.cpp
@@ -1,0 +1,72 @@
+#include <iostream>
+#include <limits>
+#include <string>
+#include "cli/commands.h"
+#include "core/Debug.h"
+
+namespace duke::cli {
+
+void adicionarMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
+    MaterialDTO m;
+    std::cout << "Nome: ";
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::getline(std::cin, m.nome);
+    std::cout << "Tipo (unitario/linear/cubico) [linear]: ";
+    std::string tipo;
+    std::getline(std::cin, tipo);
+    if (!tipo.empty()) {
+        if (tipo == "unitario" || tipo == "linear" || tipo == "cubico") {
+            m.tipo = tipo;
+        } else {
+            wr::p("APP", "Tipo invalido. Usando 'linear'.", "Yellow");
+        }
+    }
+    std::cout << "Valor: ";
+    std::cin >> m.valor;
+    std::cout << "Largura: ";
+    std::cin >> m.largura;
+    std::cout << "Comprimento: ";
+    std::cin >> m.comprimento;
+    base.push_back(m);
+    salvarReconstruir(base, mats);
+}
+
+void editarMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
+    if (base.empty()) return;
+    listarMateriais(base);
+    std::cout << "Indice para editar: ";
+    size_t idx = 0;
+    if (!(std::cin >> idx) || idx < 1 || idx > base.size()) {
+        std::cout << "Indice invalido.\n";
+        return;
+    }
+    MaterialDTO& m = base[idx - 1];
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::string nome;
+    std::cout << "Nome (" << m.nome << "): ";
+    std::getline(std::cin, nome);
+    if (!nome.empty()) m.nome = nome;
+    std::cout << "Valor (" << m.valor << "): ";
+    std::cin >> m.valor;
+    std::cout << "Largura (" << m.largura << "): ";
+    std::cin >> m.largura;
+    std::cout << "Comprimento (" << m.comprimento << "): ";
+    std::cin >> m.comprimento;
+    salvarReconstruir(base, mats);
+}
+
+void removerMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
+    if (base.empty()) return;
+    listarMateriais(base);
+    std::cout << "Indice para remover: ";
+    size_t idx = 0;
+    if (!(std::cin >> idx) || idx < 1 || idx > base.size()) {
+        std::cout << "Indice invalido.\n";
+        return;
+    }
+    base.erase(base.begin() + static_cast<long>(idx - 1));
+    salvarReconstruir(base, mats);
+}
+
+} // namespace duke::cli
+

--- a/DUKE/src/cli/parser.cpp
+++ b/DUKE/src/cli/parser.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include <limits>
+#include <string>
+#include "cli/parser.h"
+#include "core/Debug.h"
+
+namespace duke::cli {
+
+int lerOpcao12(int padrao) {
+    int opcao = padrao;
+    std::cout << "Quer o calculo com o mais barato ou com o mais caro? (1/2) | ";
+    if (!(std::cin >> opcao) || (opcao != 1 && opcao != 2)) {
+        std::cin.clear();
+        std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+        opcao = padrao;
+        wr::p("APP", "Entrada invalida. Usando opcao " + std::to_string(padrao) + ".", "Yellow");
+    }
+    return opcao;
+}
+
+} // namespace duke::cli
+

--- a/DUKE/src/cli/utils.cpp
+++ b/DUKE/src/cli/utils.cpp
@@ -1,0 +1,28 @@
+#include <iostream>
+#include "cli/utils.h"
+#include "core/format.h"
+
+namespace duke::cli {
+
+void listarMateriais(const std::vector<MaterialDTO>& base) {
+    std::cout << "\nMateriais cadastrados:\n";
+    if (base.empty()) {
+        std::cout << "(vazio)\n";
+        return;
+    }
+    for (size_t i = 0; i < base.size(); ++i) {
+        const auto& m = base[i];
+        std::cout << i + 1 << ") " << m.nome << " [" << m.tipo << "]"
+                  << " | " << UN_MONE << m.valor
+                  << " | " << m.largura << " x " << m.comprimento << UN_AREA
+                  << "\n";
+    }
+}
+
+void salvarReconstruir(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
+    mats = core::reconstruirMateriais(base);
+    ::Persist::saveJSON("materiais.json", base, 1);
+}
+
+} // namespace duke::cli
+

--- a/DUKE/tests/Makefile
+++ b/DUKE/tests/Makefile
@@ -1,0 +1,22 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -Wall -DUNIT_TEST
+CORE_DIR = ../../core
+CALC_DIR = ..
+LIB_CORE = $(CORE_DIR)/libcore.a
+LIB_DUKE = $(CALC_DIR)/libduke.a
+
+SRCS := $(wildcard *.cpp)
+
+run_tests: $(SRCS) $(LIB_DUKE) $(LIB_CORE)
+	$(CXX) $(CXXFLAGS) $(SRCS) -I$(CALC_DIR)/include -I$(CALC_DIR)/third_party -I$(CORE_DIR)/include $(LIB_DUKE) $(LIB_CORE) -o run_tests
+
+$(LIB_DUKE):
+	$(MAKE) -C $(CALC_DIR) libduke.a
+
+$(LIB_CORE):
+	$(MAKE) -C $(CORE_DIR) libcore.a
+
+clean:
+	rm -f run_tests
+
+.PHONY: run_tests clean

--- a/DUKE/tests/cli_helpers_test.cpp
+++ b/DUKE/tests/cli_helpers_test.cpp
@@ -1,0 +1,29 @@
+#include <cassert>
+#include <sstream>
+#include <vector>
+#include <iostream>
+#include "cli/parser.h"
+#include "cli/commands.h"
+
+using namespace duke;
+
+void test_lerOpcao12() {
+    std::istringstream in("3\n");
+    auto old = std::cin.rdbuf(in.rdbuf());
+    int v = cli::lerOpcao12(2);
+    std::cin.rdbuf(old);
+    assert(v == 2);
+}
+
+void test_adicionarMaterial() {
+    std::vector<MaterialDTO> base;
+    std::vector<Material> mats;
+    std::istringstream in("\nMadeira\nlinear\n10\n2\n3\n");
+    auto old = std::cin.rdbuf(in.rdbuf());
+    cli::adicionarMaterial(base, mats);
+    std::cin.rdbuf(old);
+    assert(base.size() == 1);
+    assert(mats.size() == 1);
+    assert(base[0].nome == "Madeira");
+}
+

--- a/DUKE/tests/run_tests.cpp
+++ b/DUKE/tests/run_tests.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+
+void test_lerOpcao12();
+void test_adicionarMaterial();
+
+int main() {
+    test_lerOpcao12();
+    test_adicionarMaterial();
+    return 0;
+}
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -19,6 +19,7 @@ O DUKE evoluirá em etapas para oferecer mais flexibilidade e confiabilidade.
   - Adicionar opções de ajuda e parâmetros para cálculos automatizados. ✅
   - Melhorar mensagens de erro para entradas inválidas.
   - Suporte inicial a `--projeto` e registro dos comandos `abrir`, `listar` e `comparar`. ✅
+  - Modularizar CLI em `parser`, `commands` e utilitários. ✅
 - **Testes automatizados** (novo diretório `tests/`)
   - Criar casos de teste unitários para validar comparações e rotinas de persistência.
   - Integrar com execução contínua (CI) para evitar regressões.


### PR DESCRIPTION
## Summary
- extrai parsing de opções para `cli/parser`
- isola comandos de materiais em `cli/commands`
- centraliza utilidades de materiais em `cli/utils`
- atualiza Makefile e Roadmap
- adiciona testes para parser e comandos

## Testing
- `make cli`
- `make tests`
- `./tests/run_tests`

### Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a3ba5513808327836479fdc02f6582