### PR TITLE
Tratar IDs inválidos ao parsear lista --ids

### DIFF
--- a/DUKE/src/cli/args.cpp
+++ b/DUKE/src/cli/args.cpp
@@ -6,6 +6,8 @@
 #include "cli/args.h"
 #include <string>
 #include <sstream>
+#include <charconv>
+#include <iostream>
 namespace duke {
 
 CliOptions parseArgs(int argc, char* argv[]) {
@@ -50,7 +52,15 @@ CliOptions parseArgs(int argc, char* argv[]) {
                 std::string item;
                 while (std::getline(ss, item, ',')) {
                     if (!item.empty()) {
-                        opt.ids.push_back(std::stoi(item));
+                        int id{};
+                        auto [ptr, ec] = std::from_chars(item.data(),
+                                                      item.data() + item.size(), id);
+                        if (ec == std::errc() && ptr == item.data() + item.size()) {
+                            opt.ids.push_back(id);
+                        } else {
+                            std::cerr << "Aviso: ID invalido '" << item
+                                      << "' ignorado\n";
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Validar cada ID recebido via `--ids` usando `std::from_chars`
- Registrar aviso e ignorar tokens não numéricos

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_e_68a3cae57efc8327a8aad82af5b4db69