### PR TITLE
[finance] feat: add basic domain structs

### DIFF
--- a/include/finance/Filters.h
+++ b/include/finance/Filters.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "finance/Tipos.h"
+
+namespace finance {
+
+// Estrutura de filtros para consultas de lançamentos
+struct Filtro {
+    std::optional<Tipo> tipo;              // filtra por tipo principal
+    std::optional<std::string> subtipo;    // filtra por subtipo
+    std::optional<std::string> conta;      // filtra por conta
+    std::optional<std::string> dt_ini;     // data inicial inclusiva
+    std::optional<std::string> dt_fim;     // data final inclusiva
+    std::optional<bool> entrada;           // true=entradas, false=saídas
+    std::vector<std::string> tags_all;     // todas as tags (AND)
+};
+
+} // namespace finance
+

--- a/include/finance/Lancamento.h
+++ b/include/finance/Lancamento.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "finance/Tipos.h"
+
+namespace finance {
+
+// Representa um lançamento financeiro individual
+struct Lancamento {
+    std::string id;                  // "FIN-2025-08-18-0001"
+    Tipo tipo;                       // enum principal
+    std::string subtipo;             // "insumos", "salario", etc.
+    std::string descricao;           // opcional
+    double valor;                    // >0
+    std::string moeda;               // "BRL"
+    std::string data;                // ISO "2025-08-18"
+    bool entrada;                    // true=recebível, false=saída
+    std::string projeto_id;          // opcional
+    std::string conta;               // "caixa", "banco", ...
+    std::vector<std::string> tags;   // ["maca", "cliente_x"]
+};
+
+} // namespace finance
+

--- a/include/finance/Tipos.h
+++ b/include/finance/Tipos.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// Tipos principais de movimentação financeira
+namespace finance {
+
+enum class Tipo {
+    Compra,
+    Vendas,
+    Outros,
+    Contas,
+    Investimento,
+    Cofrinho
+};
+
+} // namespace finance
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,10 +9,10 @@ LIB_CALC = $(CALC_DIR)/libduke.a
 
 CALC_SRCS := $(wildcard duke/*.cpp)
 CORE_SRCS := $(wildcard core/*.cpp)
+FIN_SRCS := $(wildcard finance/*.cpp)
 
-.PHONY: all duke core clean
-
-all: duke core
+.PHONY: all duke core finance clean
+all: duke core finance
 
 duke: $(LIB_CALC) $(LIB_CORE)
 ifeq ($(strip $(CALC_SRCS)),)
@@ -33,6 +33,14 @@ else
 	./core/run_tests
 endif
 
+finance:
+ifeq ($(strip $(FIN_SRCS)),)
+	@echo "No finance tests"
+else
+	$(CXX) $(CXXFLAGS) $(FIN_SRCS) -I../include -o finance/run_tests
+	./finance/run_tests
+endif
+
 $(LIB_CALC):
 	$(MAKE) -C $(CALC_DIR) libduke.a
 
@@ -40,4 +48,4 @@ $(LIB_CORE):
 	$(MAKE) -C $(CORE_DIR) libcore.a
 
 clean:
-	rm -f duke/run_tests core/run_tests
+	rm -f duke/run_tests core/run_tests finance/run_tests

--- a/tests/finance/lancamento_test.cpp
+++ b/tests/finance/lancamento_test.cpp
@@ -1,0 +1,35 @@
+#include <finance/Lancamento.h>
+#include <finance/Filters.h>
+#include <cassert>
+
+using namespace finance;
+
+void test_lancamento() {
+    Lancamento l{
+        "FIN-2025-08-18-0001",
+        Tipo::Compra,
+        "insumos",
+        "TNT rolo",
+        129.9,
+        "BRL",
+        "2025-08-18",
+        false,
+        "",
+        "caixa",
+        {"maca"}
+    };
+
+    assert(l.tipo == Tipo::Compra);
+    assert(!l.entrada);
+    assert(l.tags.size() == 1);
+}
+
+void test_filtro() {
+    Filtro f;
+    assert(!f.tipo);
+    f.tipo = Tipo::Vendas;
+    f.tags_all = {"cliente_x"};
+    assert(f.tipo == Tipo::Vendas);
+    assert(f.tags_all[0] == "cliente_x");
+}
+

--- a/tests/finance/run_tests.cpp
+++ b/tests/finance/run_tests.cpp
@@ -1,0 +1,11 @@
+#include <cassert>
+
+void test_lancamento();
+void test_filtro();
+
+int main() {
+    test_lancamento();
+    test_filtro();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- define `Tipo` enum and foundational finance structs
- wire up simple finance unit tests

## Testing
- `make -C tests` *(fails: duke/projeto_test.cpp assertion)*
- `make -C tests finance`

### Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [ ] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a3e5bf5a888327abc56853d05a2eec