### PR TITLE
Add finance Lancamento serialization helpers

### DIFF
--- a/include/finance/Serialize.h
+++ b/include/finance/Serialize.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <string>
+#include <nlohmann/json.hpp>
+
+#include "finance/Lancamento.h"
+#include "finance/Tipos.h"
+
+namespace finance {
+
+using nlohmann::json;
+
+std::string to_string(Tipo t);
+Tipo tipo_from_string(const std::string& s);
+
+void to_json(json& j, const Lancamento& l);
+void from_json(const json& j, Lancamento& l);
+
+} // namespace finance
+

--- a/src/finance/Serialize.cpp
+++ b/src/finance/Serialize.cpp
@@ -1,0 +1,74 @@
+#include "finance/Serialize.h"
+
+#include <stdexcept>
+
+namespace finance {
+
+std::string to_string(Tipo t) {
+    switch (t) {
+    case Tipo::Compra: return "Compra";
+    case Tipo::Vendas: return "Vendas";
+    case Tipo::Outros: return "Outros";
+    case Tipo::Contas: return "Contas";
+    case Tipo::Investimento: return "Investimento";
+    case Tipo::Cofrinho: return "Cofrinho";
+    }
+    throw std::invalid_argument("Tipo invalido");
+}
+
+Tipo tipo_from_string(const std::string& s) {
+    if (s == "Compra") return Tipo::Compra;
+    if (s == "Vendas") return Tipo::Vendas;
+    if (s == "Outros") return Tipo::Outros;
+    if (s == "Contas") return Tipo::Contas;
+    if (s == "Investimento") return Tipo::Investimento;
+    if (s == "Cofrinho") return Tipo::Cofrinho;
+    throw std::invalid_argument("tipo_from_string: " + s);
+}
+
+void to_json(json& j, const Lancamento& l) {
+    j = json{
+        {"id", l.id},
+        {"tipo", to_string(l.tipo)},
+        {"subtipo", l.subtipo},
+        {"descricao", l.descricao},
+        {"valor", l.valor},
+        {"moeda", l.moeda},
+        {"data", l.data},
+        {"entrada", l.entrada},
+        {"projeto_id", l.projeto_id},
+        {"conta", l.conta},
+        {"tags", l.tags}
+    };
+}
+
+void from_json(const json& j, Lancamento& l) {
+    std::string tipo_str;
+    j.at("id").get_to(l.id);
+    j.at("tipo").get_to(tipo_str);
+    l.tipo = tipo_from_string(tipo_str);
+    j.at("subtipo").get_to(l.subtipo);
+    if (j.contains("descricao"))
+        j.at("descricao").get_to(l.descricao);
+    else
+        l.descricao.clear();
+    j.at("valor").get_to(l.valor);
+    j.at("moeda").get_to(l.moeda);
+    j.at("data").get_to(l.data);
+    j.at("entrada").get_to(l.entrada);
+    if (j.contains("projeto_id"))
+        j.at("projeto_id").get_to(l.projeto_id);
+    else
+        l.projeto_id.clear();
+    if (j.contains("conta"))
+        j.at("conta").get_to(l.conta);
+    else
+        l.conta.clear();
+    if (j.contains("tags"))
+        j.at("tags").get_to(l.tags);
+    else
+        l.tags.clear();
+}
+
+} // namespace finance
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,13 +10,14 @@ LIB_CALC = $(CALC_DIR)/libduke.a
 CALC_SRCS := $(wildcard duke/*.cpp)
 CORE_SRCS := $(wildcard core/*.cpp)
 FIN_SRCS := $(wildcard finance/*.cpp)
+FIN_LIB_SRCS := $(wildcard ../src/finance/*.cpp)
 
 .PHONY: all duke core finance clean
 all: duke core finance
 
 duke: $(LIB_CALC) $(LIB_CORE)
 ifeq ($(strip $(CALC_SRCS)),)
-        @echo "No DUKE tests"
+	@echo "No DUKE tests"
 else
 	$(CXX) $(CXXFLAGS) -include duke/namespace.h \
 		$(CALC_SRCS) -I$(CALC_DIR)/include -I../third_party -I$(CORE_DIR)/include \
@@ -37,7 +38,7 @@ finance:
 ifeq ($(strip $(FIN_SRCS)),)
 	@echo "No finance tests"
 else
-	$(CXX) $(CXXFLAGS) $(FIN_SRCS) -I../include -o finance/run_tests
+	$(CXX) $(CXXFLAGS) $(FIN_SRCS) $(FIN_LIB_SRCS) -I../include -I../third_party -o finance/run_tests
 	./finance/run_tests
 endif
 

--- a/tests/finance/run_tests.cpp
+++ b/tests/finance/run_tests.cpp
@@ -2,10 +2,14 @@
 
 void test_lancamento();
 void test_filtro();
+void test_tipo_string();
+void test_serialize();
 
 int main() {
     test_lancamento();
     test_filtro();
+    test_tipo_string();
+    test_serialize();
     return 0;
 }
 

--- a/tests/finance/serialize_test.cpp
+++ b/tests/finance/serialize_test.cpp
@@ -1,0 +1,35 @@
+#include <finance/Serialize.h>
+#include <cassert>
+#include <nlohmann/json.hpp>
+
+using namespace finance;
+using nlohmann::json;
+
+void test_tipo_string() {
+    assert(to_string(Tipo::Compra) == "Compra");
+    assert(to_string(Tipo::Vendas) == "Vendas");
+    assert(tipo_from_string("Contas") == Tipo::Contas);
+}
+
+void test_serialize() {
+    Lancamento l{
+        "FIN-2025-08-18-0001",
+        Tipo::Compra,
+        "insumos",
+        "TNT rolo",
+        129.9,
+        "BRL",
+        "2025-08-18",
+        false,
+        "",
+        "caixa",
+        {"maca"}
+    };
+
+    json j = l;
+    Lancamento l2 = j.get<Lancamento>();
+    assert(l2.id == l.id);
+    assert(l2.tipo == l.tipo);
+    assert(l2.tags.size() == 1 && l2.tags[0] == "maca");
+}
+


### PR DESCRIPTION
## Summary
- add enum-string mapping helpers for `Tipo`
- implement JSON serialization for `Lancamento`
- test finance serialization utilities

## Testing
- `make -C tests` *(fails: run_tests: duke/projeto_test.cpp:18: void test_projeto(): Assertion `prj.adicionarMaterial(mat)` failed.)*
- `make -C tests finance`


------
https://chatgpt.com/codex/tasks/task_e_68a3e8b413348327a2f315604570cb34