### PR TITLE
[build] feat: integrar Qt 6

### DIFF
--- a/DUKE/Makefile
+++ b/DUKE/Makefile
@@ -2,6 +2,9 @@ CXX = g++
 CXXFLAGS = -std=c++17 -Wall -fPIC
 CORE_DIR = ../core
 INCLUDES = -Iinclude -I../include -I../third_party -I$(CORE_DIR)/include
+QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets)
+QT_LIBS := $(shell pkg-config --libs Qt6Widgets)
+CXXFLAGS += $(QT_CFLAGS)
 
 CORE_LIB = $(CORE_DIR)/libcore.a
 
@@ -19,13 +22,13 @@ libduke.a: $(OBJ) $(CORE_LIB)
 	ar rcs $@ $(OBJ)
 
 libduke.so: $(OBJ) $(CORE_LIB)
-	$(CXX) $(CXXFLAGS) -shared $(OBJ) -L$(CORE_DIR) -lcore -o $@
+	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(QT_LIBS) -L$(CORE_DIR) -lcore -o $@
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 cli: libduke.a $(CORE_LIB) src/main.cpp
-	$(CXX) $(CXXFLAGS) src/main.cpp $(INCLUDES) -L. -lduke -L$(CORE_DIR) -lcore -o app
+	$(CXX) $(CXXFLAGS) src/main.cpp $(INCLUDES) -L. -lduke -L$(CORE_DIR) -lcore $(QT_LIBS) -o app
 
 tests: libduke.a $(CORE_LIB)
 	$(MAKE) -C tests run_tests

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 ERP DUKE é um sistema ERP modular voltado para o planejamento de cortes de materiais e gestão de projetos.
 
+## Requisitos
+
+O sistema depende da toolkit [Qt 6](https://www.qt.io/qt-6).
+Instale as bibliotecas de desenvolvimento e garanta que `pkg-config`
+as encontre antes de compilar.
+
 ## Compilação
 
 O projeto é dividido em módulos compilados separadamente.

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,6 +1,9 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -Wall -fPIC
 INCLUDES = -Iinclude
+QT_CFLAGS := $(shell pkg-config --cflags Qt6Core)
+QT_LIBS := $(shell pkg-config --libs Qt6Core)
+CXXFLAGS += $(QT_CFLAGS)
 
 SRC = $(wildcard src/*.cpp)
 OBJ = $(SRC:src/%.cpp=%.o)
@@ -11,7 +14,7 @@ libcore.a: $(OBJ)
 	ar rcs $@ $(OBJ)
 
 libcore.so: $(OBJ)
-	$(CXX) $(CXXFLAGS) -shared $(OBJ) -o $@
+	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(QT_LIBS) -o $@
 
 %.o: src/%.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,5 +1,10 @@
 # Uso via CLI
 
+## Dependências
+
+A CLI utiliza a toolkit [Qt 6](https://www.qt.io/qt-6). Certifique-se de que as
+bibliotecas estejam instaladas e disponíveis via `pkg-config` antes da compilação.
+
 O DUKE pode ser executado com as seguintes opções:
 
 ```bash


### PR DESCRIPTION
## Summary
- configure core and DUKE builds to query Qt 6 via pkg-config
- document Qt 6 as build prerequisite

## Testing
- `make -C core`
- `make -C DUKE tests` *(fails: finance/Repo.h: No such file or directory)*

### Checklist
- [x] Revisão de código
- [ ] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a461998ad483278e5550e4c977c39a