### PR TITLE
[gui] feat: widgets de navegação

### DIFF
--- a/DUKE/Makefile
+++ b/DUKE/Makefile
@@ -12,7 +12,7 @@ CLI_SRC := src/cli/app.cpp src/cli/args.cpp src/cli/parser.cpp src/cli/utils.cpp
 FIN_SRC := $(wildcard ../src/finance/*.cpp)
 SRC := $(wildcard src/*.cpp) $(CLI_SRC) \
        $(wildcard src/domain/*.cpp) $(wildcard src/custo/*.cpp) \
-       $(wildcard src/ui/*.cpp) $(FIN_SRC)
+       $(wildcard src/ui/*.cpp) $(wildcard src/gui/*.cpp) $(FIN_SRC)
 LIB_SRC := $(filter-out src/main.cpp,$(SRC))
 OBJ := $(LIB_SRC:.cpp=.o)
 

--- a/DUKE/include/gui/GuiBridge.h
+++ b/DUKE/include/gui/GuiBridge.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <vector>
+#include "ApplicationCore.h"
+#include "Material.h"
+#include "core.h"
+
+namespace duke {
+namespace gui {
+
+// ==========================================
+// Classe: GuiBridge
+// Descrição: conecta eventos do GUI aos métodos
+//            de ApplicationCore.
+// Exemplo de uso:
+//   GuiBridge b(core, base, mats);
+//   b.selecionarMaterial(0);
+// ==========================================
+class GuiBridge {
+public:
+    GuiBridge(ApplicationCore& core,
+              const std::vector<MaterialDTO>& base,
+              const std::vector<Material>& mats);
+
+    void selecionarMaterial(int idx);
+    int ultimaSelecao() const { return m_last; }
+
+private:
+    ApplicationCore& m_core;
+    const std::vector<MaterialDTO>& m_base;
+    const std::vector<Material>& m_mats;
+    int m_last = -1;
+};
+
+} // namespace gui
+} // namespace duke
+

--- a/DUKE/include/gui/Navigation.h
+++ b/DUKE/include/gui/Navigation.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <functional>
+#include <ostream>
+
+namespace duke {
+namespace gui {
+
+// ==========================================
+// Widget: ClearScreenWidget
+// Descrição: limpa a área de saída.
+// Exemplo de uso:
+//   ClearScreenWidget w; w.render(std::cout);
+// ==========================================
+class ClearScreenWidget {
+public:
+    void render(std::ostream& out) const;
+};
+
+// ==========================================
+// Widget: MenuKeyWidget
+// Descrição: exibe opções com teclas associadas e dispara
+//            callback ao selecionar.
+// Exemplo de uso:
+//   MenuKeyWidget w(opts, keys, [](int i){ /*...*/ });
+//   w.render(std::cout);
+//   w.onKey('a');
+// ==========================================
+class MenuKeyWidget {
+public:
+    MenuKeyWidget(std::vector<std::string> opts,
+                  std::vector<char> keys,
+                  std::function<void(int)> onSelect);
+
+    void render(std::ostream& out) const;
+    void onKey(char c);
+
+private:
+    std::vector<std::string> m_opts;
+    std::vector<char> m_keys;
+    std::function<void(int)> m_onSelect;
+};
+
+// ==========================================
+// Widget: MenuWidget
+// Descrição: exibe menu numerado e aciona callback
+//            ao receber índice válido.
+// Exemplo de uso:
+//   MenuWidget w(opts, [](int i){ /*...*/ });
+//   w.render(std::cout);
+//   w.onInput(1);
+// ==========================================
+class MenuWidget {
+public:
+    MenuWidget(std::vector<std::string> opts,
+               std::function<void(int)> onSelect);
+
+    void render(std::ostream& out) const;
+    void onInput(int idx);
+
+private:
+    std::vector<std::string> m_opts;
+    std::function<void(int)> m_onSelect;
+};
+
+// ==========================================
+// Widget: BreadcrumbWidget
+// Descrição: exibe trilha de navegação.
+// Exemplo de uso:
+//   BreadcrumbWidget w(trail); w.render(std::cout);
+// ==========================================
+class BreadcrumbWidget {
+public:
+    explicit BreadcrumbWidget(const std::vector<std::string>& trail);
+    void render(std::ostream& out) const;
+
+private:
+    const std::vector<std::string>& m_trail;
+};
+
+} // namespace gui
+} // namespace duke
+

--- a/DUKE/src/gui/GuiBridge.cpp
+++ b/DUKE/src/gui/GuiBridge.cpp
@@ -1,0 +1,19 @@
+#include "gui/GuiBridge.h"
+
+namespace duke {
+namespace gui {
+
+GuiBridge::GuiBridge(ApplicationCore& core,
+                     const std::vector<MaterialDTO>& base,
+                     const std::vector<Material>& mats)
+    : m_core(core), m_base(base), m_mats(mats) {}
+
+void GuiBridge::selecionarMaterial(int idx) {
+    // Chama listarMateriais apenas para demonstrar conexão.
+    m_core.listarMateriais(m_base);
+    m_last = idx;
+}
+
+} // namespace gui
+} // namespace duke
+

--- a/DUKE/src/gui/Navigation.cpp
+++ b/DUKE/src/gui/Navigation.cpp
@@ -1,0 +1,66 @@
+#include "gui/Navigation.h"
+#include <cctype>
+
+namespace duke {
+namespace gui {
+
+void ClearScreenWidget::render(std::ostream& out) const {
+    out << "\033[2J\033[1;1H";
+}
+
+MenuKeyWidget::MenuKeyWidget(std::vector<std::string> opts,
+                             std::vector<char> keys,
+                             std::function<void(int)> onSelect)
+    : m_opts(std::move(opts)),
+      m_keys(std::move(keys)),
+      m_onSelect(std::move(onSelect)) {}
+
+void MenuKeyWidget::render(std::ostream& out) const {
+    for (size_t i = 0; i < m_opts.size(); ++i) {
+        out << m_keys[i] << ") " << m_opts[i] << "\n";
+    }
+    out << "> ";
+}
+
+void MenuKeyWidget::onKey(char c) {
+    char u = static_cast<char>(std::toupper(c));
+    for (size_t i = 0; i < m_keys.size(); ++i) {
+        if (u == static_cast<char>(std::toupper(m_keys[i]))) {
+            if (m_onSelect) m_onSelect(static_cast<int>(i));
+            return;
+        }
+    }
+}
+
+MenuWidget::MenuWidget(std::vector<std::string> opts,
+                       std::function<void(int)> onSelect)
+    : m_opts(std::move(opts)),
+      m_onSelect(std::move(onSelect)) {}
+
+void MenuWidget::render(std::ostream& out) const {
+    for (size_t i = 0; i < m_opts.size(); ++i) {
+        out << i + 1 << ") " << m_opts[i] << "\n";
+    }
+    out << "> ";
+}
+
+void MenuWidget::onInput(int idx) {
+    if (idx >= 1 && static_cast<size_t>(idx) <= m_opts.size()) {
+        if (m_onSelect) m_onSelect(idx - 1);
+    }
+}
+
+BreadcrumbWidget::BreadcrumbWidget(const std::vector<std::string>& trail)
+    : m_trail(trail) {}
+
+void BreadcrumbWidget::render(std::ostream& out) const {
+    for (size_t i = 0; i < m_trail.size(); ++i) {
+        if (i > 0) out << " > ";
+        out << m_trail[i];
+    }
+    out << '\n';
+}
+
+} // namespace gui
+} // namespace duke
+

--- a/DUKE/tests/Makefile
+++ b/DUKE/tests/Makefile
@@ -8,7 +8,7 @@ LIB_DUKE = $(CALC_DIR)/libduke.a
 SRCS := $(wildcard *.cpp)
 
 run_tests: $(SRCS) $(LIB_DUKE) $(LIB_CORE)
-	$(CXX) $(CXXFLAGS) $(SRCS) -I$(CALC_DIR)/include -I$(CALC_DIR)/../third_party -I$(CORE_DIR)/include $(LIB_DUKE) $(LIB_CORE) -o run_tests
+	$(CXX) $(CXXFLAGS) $(SRCS) -I$(CALC_DIR)/include -I$(CALC_DIR)/../include -I$(CALC_DIR)/../third_party -I$(CORE_DIR)/include $(LIB_DUKE) $(LIB_CORE) -o run_tests
 
 $(LIB_DUKE):
 	$(MAKE) -C $(CALC_DIR) libduke.a

--- a/DUKE/tests/gui_menu_widget_test.cpp
+++ b/DUKE/tests/gui_menu_widget_test.cpp
@@ -1,0 +1,25 @@
+#include <cassert>
+#include <vector>
+#include <string>
+#include "gui/Navigation.h"
+#include "gui/GuiBridge.h"
+
+using namespace duke;
+
+void test_menu_key_widget_calls_core() {
+    ApplicationCore core;
+    std::vector<MaterialDTO> base{
+        {"Madeira", 10.0, 0.1, 1.0, "linear"},
+        {"Metal", 20.0, 0.2, 2.0, "linear"}
+    };
+    auto mats = core::reconstruirMateriais(base);
+    gui::GuiBridge bridge(core, base, mats);
+
+    std::vector<std::string> opts{"A", "B"};
+    std::vector<char> keys{'a', 'b'};
+    gui::MenuKeyWidget menu(opts, keys, [&](int idx){ bridge.selecionarMaterial(idx); });
+
+    menu.onKey('b');
+    assert(bridge.ultimaSelecao() == 1);
+}
+

--- a/DUKE/tests/run_tests.cpp
+++ b/DUKE/tests/run_tests.cpp
@@ -5,6 +5,7 @@ void test_adicionarMaterial();
 void test_importarCSV_ignore();
 void test_exportar_ignore();
 void test_parseArgs_unknown();
+void test_menu_key_widget_calls_core();
 
 int main() {
     test_lerOpcao12();
@@ -12,6 +13,7 @@ int main() {
     test_importarCSV_ignore();
     test_exportar_ignore();
     test_parseArgs_unknown();
+    test_menu_key_widget_calls_core();
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- reimplement navigation helpers as widget classes
- bridge GUI events to ApplicationCore
- cover GUI menu selection with tests

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -I../include -I../third_party -I../core/include -o app` *(fails: undefined references)*
- `make cli`
- `make tests`
- `./tests/run_tests`

### 📝 Checklist deste PR
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a464c1206c83279ca1e9c2a10ed885