### PR TITLE
[DUKE] fix: aceitar dimensões zeradas em materiais unitários

### DIFF
--- a/DUKE/include/domain/Projeto.h
+++ b/DUKE/include/domain/Projeto.h
@@ -47,7 +47,7 @@ public:
 
     // Adiciona um material ao projeto. Retorna falso em caso de validação falha.
     // Exemplo:
-    //   ProjetoItemMaterial it{"madeira", 2, {}, 10.0};
+    //   ProjetoItemMaterial it{"madeira", 2, {}, 10.0}; // dimensões não usadas podem ser zero
     //   prj.adicionarMaterial(it);
     bool adicionarMaterial(const ProjetoItemMaterial& item);
 

--- a/DUKE/src/domain/Projeto.cpp
+++ b/DUKE/src/domain/Projeto.cpp
@@ -7,9 +7,10 @@
 #include "domain/Tempo.h"
 namespace duke {
 
-// Retorna false se qualquer dimensão for menor ou igual a zero
+// Retorna false se alguma dimensão for negativa. Valores zero são aceitos
+// para dimensões não utilizadas, como em materiais unitários.
 static bool medidasValidas(const Medidas& m) {
-    if (m.largura <= 0 || m.altura <= 0 || m.profundidade <= 0 || m.comprimento <= 0)
+    if (m.largura < 0 || m.altura < 0 || m.profundidade < 0 || m.comprimento < 0)
         return false;
     return true;
 }

--- a/tests/duke/projeto_test.cpp
+++ b/tests/duke/projeto_test.cpp
@@ -24,6 +24,14 @@ void test_projeto() {
     inval.medidas.comprimento = 1.0;
     assert(!prj.adicionarMaterial(inval));
 
+    // Material com dimensões zeradas (válido para materiais unitários)
+    ProjetoItemMaterial matZero;
+    matZero.idMaterial = "mat_unit";
+    matZero.quantidade = 1;
+    matZero.custoUnitario = 3.0;
+    // Medidas permanecem em 0.0
+    assert(prj.adicionarMaterial(matZero));
+
     // Corte válido
     ProjetoItemCorte ct;
     ct.idMaterial = "mat1";
@@ -45,11 +53,12 @@ void test_projeto() {
     ctInv.quantidade = 1;
     assert(!prj.adicionarCorte(ctInv));
 
-    // Resumo de custo
-    assert(prj.resumoCusto() == 2*5.0 + 1*1.0);
+    // Resumo de custo inclui materiais unitários com medidas zeradas
+    assert(prj.resumoCusto() == 2*5.0 + 1*1.0 + 1*3.0);
 
     // Remoção
     assert(prj.removerItem("mat1"));
+    assert(prj.removerItem("mat_unit"));
     assert(prj.materiais.empty());
     assert(prj.cortes.empty());
 


### PR DESCRIPTION
## Summary
- allow zero-valued dimensions for unused material measures
- document optional dimensions
- cover unit materials with zero dimensions in tests

## Testing
- `make -C tests duke`
- `make -C DUKE/tests run_tests`
- `./DUKE/tests/run_tests`

------
https://chatgpt.com/codex/tasks/task_e_68a4764f5a2c8327a574433f29e7982f