### PR TITLE
Gracefully handle malformed --valor in CLI

### DIFF
--- a/DUKE/src/cli/args.cpp
+++ b/DUKE/src/cli/args.cpp
@@ -48,7 +48,15 @@ CliOptions parseArgs(int argc, char* argv[]) {
                     valor = a.substr(a.find('=') + 1);
                 }
                 if (!valor.empty()) {
-                    opt.finValor = std::stod(valor);
+                    double val{};
+                    auto [ptr, ec] = std::from_chars(valor.data(),
+                                                    valor.data() + valor.size(), val);
+                    if (ec == std::errc() && ptr == valor.data() + valor.size()) {
+                        opt.finValor = val;
+                    } else {
+                        wr::p("CLI", "Valor invalido '" + valor + "'", "Yellow");
+                        opt.ok = false;
+                    }
                 }
             } else if (a.rfind("--data", 0) == 0) {
                 std::string valor;

--- a/tests/duke/cli_test.cpp
+++ b/tests/duke/cli_test.cpp
@@ -46,4 +46,10 @@ void test_cli() {
     CliOptions o9 = parseArgs(3, const_cast<char**>(a9));
     assert(o9.ids.size() == 3);
     assert(o9.ids[0] == 1 && o9.ids[1] == 3 && o9.ids[2] == 5);
+
+    // testa --valor malformado
+    const char* a10[] = {"app", "fin", "add", "--valor", "abc"};
+    CliOptions o10 = parseArgs(5, const_cast<char**>(a10));
+    assert(!o10.finValor.has_value());
+    assert(!o10.ok);
 }


### PR DESCRIPTION
## Summary
- parse `--valor` using `std::from_chars` and warn on failure
- test malformed `--valor` argument

## Testing
- `g++ -std=c++17 -Wall -DUNIT_TEST -include duke/namespace.h cli_test_main.cpp duke/cli_test.cpp -I../DUKE/include -I../include -I../third_party -I../core/include ../DUKE/libduke.a ../core/libcore.a -o cli_test_runner && ./cli_test_runner`
- `make duke` *(fails: command hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a4827d2a4c8327b99431aa7a3876a3