### PR TITLE
[gui] feat: janela principal básica

### DIFF
--- a/DUKE/include/gui/MainWindow.h
+++ b/DUKE/include/gui/MainWindow.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QMainWindow>
+
+QT_BEGIN_NAMESPACE
+class QWidget;
+class QVBoxLayout;
+class QPushButton;
+QT_END_NAMESPACE
+
+#include "gui/GuiBridge.h"
+
+namespace duke {
+namespace gui {
+
+// ==========================================
+// Classe: MainWindow
+// Descrição: janela principal da aplicação.
+// Exemplo de uso:
+//   MainWindow w(&bridge, nullptr, nullptr, nullptr);
+// ==========================================
+class MainWindow : public QMainWindow {
+public:
+    // Construtor: prepara a janela com ponteiros para widgets.
+    MainWindow(gui::GuiBridge* bridge,
+               QWidget* centralWidget,
+               QVBoxLayout* layout,
+               QPushButton* selectButton);
+
+    // Destrutor padrão.
+    ~MainWindow() override = default;
+
+private:
+    gui::GuiBridge* m_bridge;
+    QWidget* m_centralWidget;
+    QVBoxLayout* m_layout;
+    QPushButton* m_selectButton;
+};
+
+} // namespace gui
+} // namespace duke
+

--- a/DUKE/src/gui/MainWindow.cpp
+++ b/DUKE/src/gui/MainWindow.cpp
@@ -1,0 +1,43 @@
+#include "gui/MainWindow.h"
+
+#include <QWidget>
+#include <QVBoxLayout>
+#include <QPushButton>
+#include <QObject>
+
+namespace duke {
+namespace gui {
+
+// Construtor: inicializa widgets e conecta eventos.
+MainWindow::MainWindow(gui::GuiBridge* bridge,
+                       QWidget* centralWidget,
+                       QVBoxLayout* layout,
+                       QPushButton* selectButton)
+    : QMainWindow(nullptr),
+      m_bridge(bridge),
+      m_centralWidget(centralWidget),
+      m_layout(layout),
+      m_selectButton(selectButton) {
+    // cria widget central se não informado
+    if (!m_centralWidget) {
+        m_centralWidget = new QWidget(this);
+    }
+    // cria layout vertical se não informado
+    if (!m_layout) {
+        m_layout = new QVBoxLayout(m_centralWidget);
+    }
+    // cria botão de seleção se não informado
+    if (!m_selectButton) {
+        m_selectButton = new QPushButton("Selecionar", m_centralWidget);
+    }
+    // associa hierarquia de widgets
+    setCentralWidget(m_centralWidget);
+    m_layout->addWidget(m_selectButton);
+    // conecta clique do botão à ponte de seleção
+    QObject::connect(m_selectButton, &QPushButton::clicked,
+                     [this]() { if (m_bridge) m_bridge->selecionarMaterial(0); });
+}
+
+} // namespace gui
+} // namespace duke
+

--- a/DUKE/tests/Makefile
+++ b/DUKE/tests/Makefile
@@ -1,5 +1,8 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -Wall -DUNIT_TEST
+QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets)
+QT_LIBS := $(shell pkg-config --libs Qt6Widgets)
+CXXFLAGS += $(QT_CFLAGS)
 CORE_DIR = ../../core
 CALC_DIR = ..
 LIB_CORE = $(CORE_DIR)/libcore.a
@@ -8,7 +11,7 @@ LIB_DUKE = $(CALC_DIR)/libduke.a
 SRCS := $(wildcard *.cpp)
 
 run_tests: $(SRCS) $(LIB_DUKE) $(LIB_CORE)
-	$(CXX) $(CXXFLAGS) $(SRCS) -I$(CALC_DIR)/include -I$(CALC_DIR)/../include -I$(CALC_DIR)/../third_party -I$(CORE_DIR)/include $(LIB_DUKE) $(LIB_CORE) -o run_tests
+	$(CXX) $(CXXFLAGS) $(SRCS) -I$(CALC_DIR)/include -I$(CALC_DIR)/../include -I$(CALC_DIR)/../third_party -I$(CORE_DIR)/include $(LIB_DUKE) $(LIB_CORE) $(QT_LIBS) -o run_tests
 
 $(LIB_DUKE):
 	$(MAKE) -C $(CALC_DIR) libduke.a

--- a/DUKE/tests/main_window_test.cpp
+++ b/DUKE/tests/main_window_test.cpp
@@ -1,0 +1,34 @@
+#include <cassert>
+#include <vector>
+#include <cstdlib>
+#include <QApplication>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include "gui/MainWindow.h"
+#include "gui/GuiBridge.h"
+
+using namespace duke;
+
+// Testa se o clique no botão chama GuiBridge::selecionarMaterial.
+void test_main_window_button_calls_bridge() {
+    setenv("QT_QPA_PLATFORM", "offscreen", 1);
+    int argc = 0;
+    char** argv = nullptr;
+    QApplication app(argc, argv);
+
+    ApplicationCore core;
+    std::vector<MaterialDTO> base{
+        {"Madeira", 10.0, 0.1, 1.0, "linear"}
+    };
+    auto mats = core::reconstruirMateriais(base);
+    gui::GuiBridge bridge(core, base, mats);
+
+    auto central = new QWidget;
+    auto layout = new QVBoxLayout(central);
+    auto button = new QPushButton("Selecionar");
+
+    gui::MainWindow window(&bridge, central, layout, button);
+    button->click();
+
+    assert(bridge.ultimaSelecao() == 0);
+}

--- a/DUKE/tests/run_tests.cpp
+++ b/DUKE/tests/run_tests.cpp
@@ -6,6 +6,7 @@ void test_importarCSV_ignore();
 void test_exportar_ignore();
 void test_parseArgs_unknown();
 void test_menu_key_widget_calls_core();
+void test_main_window_button_calls_bridge();
 
 int main() {
     test_lerOpcao12();
@@ -14,6 +15,7 @@ int main() {
     test_exportar_ignore();
     test_parseArgs_unknown();
     test_menu_key_widget_calls_core();
+    test_main_window_button_calls_bridge();
     return 0;
 }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -21,6 +21,8 @@ O DUKE evoluirá em etapas para oferecer mais flexibilidade e confiabilidade.
   - Melhorar mensagens de erro para entradas inválidas.
   - Suporte inicial a `--projeto` e registro dos comandos `abrir`, `listar` e `comparar`. ✅
   - Modularizar CLI em `parser`, `commands` e utilitários. ✅
+- **Interface gráfica básica** (`DUKE/gui/MainWindow`)
+  - Janela principal com botão para selecionar material. ✅
 - **Financeiro** (`fin add|list|sum`)
   - CLI para registrar, listar e somar lançamentos com filtros. ✅
   - Relatório mensal com `fin report mes --ano=<AAAA> --mes=<MM>` exportando CSV. ✅


### PR DESCRIPTION
## Summary
- create MainWindow derived from QMainWindow with botão de seleção
- hook button click to GuiBridge and add unit test
- document roadmap entry for interface gráfica básica

## Testing
- `make -C DUKE tests`
- `QT_QPA_PLATFORM=offscreen DUKE/tests/run_tests`

### Checklist
- [x] Revisão de código
- [x] Testes adicionados e rodando
- [x] Documentação atualizada
- [x] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a4c5e267a883278831f93293282241