### PR TITLE
Integrar GuiBridge ao Qt com sinais/slots

### DIFF
--- a/DUKE/include/gui/GuiBridge.h
+++ b/DUKE/include/gui/GuiBridge.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <QObject>
 #include "ApplicationCore.h"
 #include "Material.h"
 #include "core.h"
@@ -16,20 +17,26 @@ namespace gui {
 //   GuiBridge b(core, base, mats);
 //   b.selecionarMaterial(0);
 // ==========================================
-class GuiBridge {
+class GuiBridge : public QObject {
+    Q_OBJECT
+
 public:
     GuiBridge(ApplicationCore& core,
               const std::vector<MaterialDTO>& base,
-              const std::vector<Material>& mats);
+              const std::vector<Material>& mats,
+              QObject* parent = nullptr);
 
+public slots:
     void selecionarMaterial(int idx);
+
+public:
     int ultimaSelecao() const { return m_last; }
 
 private:
     ApplicationCore& m_core;
     const std::vector<MaterialDTO>& m_base;
     const std::vector<Material>& m_mats;
-    int m_last = -1;
+    int m_last;
 };
 
 } // namespace gui

--- a/DUKE/src/gui/GuiBridge.cpp
+++ b/DUKE/src/gui/GuiBridge.cpp
@@ -1,14 +1,18 @@
 #include "gui/GuiBridge.h"
+#include "core/Debug.h"
+#include <string>
 
 namespace duke {
 namespace gui {
 
 GuiBridge::GuiBridge(ApplicationCore& core,
                      const std::vector<MaterialDTO>& base,
-                     const std::vector<Material>& mats)
-    : m_core(core), m_base(base), m_mats(mats) {}
+                     const std::vector<Material>& mats,
+                     QObject* parent)
+    : QObject{parent}, m_core(core), m_base(base), m_mats(mats), m_last{-1} {}
 
 void GuiBridge::selecionarMaterial(int idx) {
+    wr::p("GUI", "Selecionando material " + std::to_string(idx), "Blue");
     // Chama listarMateriais apenas para demonstrar conexão.
     m_core.listarMateriais(m_base);
     m_last = idx;


### PR DESCRIPTION
## Summary
- Converte GuiBridge para herdar de QObject e utiliza macro Q_OBJECT
- Move selecionarMaterial para seção de slots e adiciona logging com wr::p
- Inicializa corretamente os membros e permite injeção de parent QObject

## Testing
- `make -C core`
- `make -C DUKE` *(falha: fatal error: QObject: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d3fb04e48327976c8a51ee52af1c