### PR TITLE
Add modular app skeleton and BOM model

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,0 +1,14 @@
+# Top‑level CMakeLists for building DUKE ERP apps
+
+cmake_minimum_required(VERSION 3.10)
+
+project(duke_apps)
+
+# Add subdirectories for each app.  Each app will be built into its own
+# executable.  These directories contain their own CMakeLists that link
+# against the core libraries.
+add_subdirectory(sales)
+add_subdirectory(production)
+add_subdirectory(admin)
+add_subdirectory(designer)
+

--- a/apps/admin/AdminApp.cpp
+++ b/apps/admin/AdminApp.cpp
@@ -1,0 +1,62 @@
+#include "AdminApp.h"
+#include <iostream>
+#include "finance/Repo.h"
+
+AdminApp::AdminApp() : repo_(new finance::FinanceRepo()) {
+    repo_->load();
+}
+
+AdminApp::~AdminApp() {
+    delete repo_;
+}
+
+int AdminApp::run(int argc, char** argv) {
+    if (argc < 2) {
+        showHelp();
+        return 0;
+    }
+    std::string command = argv[1];
+    std::vector<std::string> args(argv + 2, argv + argc);
+    if (command == "fin-add") {
+        handleAddTransaction(args);
+    } else if (command == "fin-list") {
+        handleListTransactions();
+    } else if (command == "fin-sum") {
+        handleSumTransactions(args);
+    } else if (command == "suppliers") {
+        handleSuppliers();
+    } else {
+        std::cerr << "Unknown command: " << command << "\n";
+        showHelp();
+    }
+    return 0;
+}
+
+void AdminApp::showHelp() const {
+    std::cout << "DUKE Admin App Commands:\n";
+    std::cout << "  fin-add <args>        Add a new financial transaction\n";
+    std::cout << "  fin-list              List all financial transactions\n";
+    std::cout << "  fin-sum <filters>     Sum transactions by criteria\n";
+    std::cout << "  suppliers             Manage supplier catalogue\n";
+}
+
+void AdminApp::handleAddTransaction(const std::vector<std::string>& args) {
+    std::cout << "Adding transaction...\n";
+    // TODO: parse arguments and call repo_->add(...)
+}
+
+void AdminApp::handleListTransactions() const {
+    std::cout << "Listing transactions...\n";
+    // TODO: iterate over repo_ entries
+}
+
+void AdminApp::handleSumTransactions(const std::vector<std::string>& args) const {
+    std::cout << "Summing transactions...\n";
+    // TODO: call repo_->sum(...) with filters
+}
+
+void AdminApp::handleSuppliers() const {
+    std::cout << "Managing suppliers...\n";
+    // TODO: implement supplier management
+}
+

--- a/apps/admin/AdminApp.h
+++ b/apps/admin/AdminApp.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace finance {
+class FinanceRepo;
+}
+
+// AdminApp encapsulates the CLI for the Administration/Finance module.  It
+// provides commands to manage financial records, suppliers and reports.
+class AdminApp {
+public:
+    AdminApp();
+    ~AdminApp();
+    int run(int argc, char** argv);
+
+private:
+    void showHelp() const;
+    void handleAddTransaction(const std::vector<std::string>& args);
+    void handleListTransactions() const;
+    void handleSumTransactions(const std::vector<std::string>& args) const;
+    void handleSuppliers() const;
+
+    finance::FinanceRepo* repo_;
+};
+

--- a/apps/admin/CMakeLists.txt
+++ b/apps/admin/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(duke_admin_app)
+
+add_executable(duke_admin main.cpp AdminApp.cpp)
+
+target_include_directories(duke_admin PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/include
+    ${CMAKE_SOURCE_DIR}/DUKE/include
+    ${CMAKE_SOURCE_DIR}/finance/include
+)
+
+target_link_libraries(duke_admin PRIVATE core duke finance)
+

--- a/apps/admin/main.cpp
+++ b/apps/admin/main.cpp
@@ -1,0 +1,7 @@
+#include "AdminApp.h"
+
+int main(int argc, char** argv) {
+    AdminApp app;
+    return app.run(argc, argv);
+}
+

--- a/apps/designer/CMakeLists.txt
+++ b/apps/designer/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(duke_designer_app)
+
+add_executable(duke_designer main.cpp DesignerApp.cpp)
+
+target_include_directories(duke_designer PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/include
+    ${CMAKE_SOURCE_DIR}/DUKE/include
+    ${CMAKE_SOURCE_DIR}/finance/include
+)
+
+target_link_libraries(duke_designer PRIVATE core duke finance)
+

--- a/apps/designer/DesignerApp.cpp
+++ b/apps/designer/DesignerApp.cpp
@@ -1,0 +1,49 @@
+#include "DesignerApp.h"
+#include <iostream>
+
+DesignerApp::DesignerApp() {}
+
+DesignerApp::~DesignerApp() {}
+
+int DesignerApp::run(int argc, char** argv) {
+    if (argc < 2) {
+        showHelp();
+        return 0;
+    }
+    std::string command = argv[1];
+    std::vector<std::string> args(argv + 2, argv + argc);
+    if (command == "new") {
+        handleNewProject(args);
+    } else if (command == "load") {
+        handleLoadProject(args);
+    } else if (command == "export-bom") {
+        handleExportBOM(args);
+    } else {
+        std::cerr << "Unknown command: " << command << "\n";
+        showHelp();
+    }
+    return 0;
+}
+
+void DesignerApp::showHelp() const {
+    std::cout << "DUKE Designer App Commands:\n";
+    std::cout << "  new <name>                Create a new design project\n";
+    std::cout << "  load <file>               Load a design project\n";
+    std::cout << "  export-bom <file>         Export Bill of Materials for the current design\n";
+}
+
+void DesignerApp::handleNewProject(const std::vector<std::string>& args) {
+    std::cout << "Creating new project...\n";
+    // TODO: initialize a new design canvas
+}
+
+void DesignerApp::handleLoadProject(const std::vector<std::string>& args) {
+    std::cout << "Loading project...\n";
+    // TODO: load project from file and display in canvas
+}
+
+void DesignerApp::handleExportBOM(const std::vector<std::string>& args) const {
+    std::cout << "Exporting BOM...\n";
+    // TODO: export list of materials for current design
+}
+

--- a/apps/designer/DesignerApp.h
+++ b/apps/designer/DesignerApp.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// DesignerApp allows users to create and edit product designs.  It
+// provides a canvas for assembling components, associating materials and
+// estimating costs.
+class DesignerApp {
+public:
+    DesignerApp();
+    ~DesignerApp();
+    int run(int argc, char** argv);
+
+private:
+    void showHelp() const;
+    void handleNewProject(const std::vector<std::string>& args);
+    void handleLoadProject(const std::vector<std::string>& args);
+    void handleExportBOM(const std::vector<std::string>& args) const;
+};
+

--- a/apps/designer/main.cpp
+++ b/apps/designer/main.cpp
@@ -1,0 +1,7 @@
+#include "DesignerApp.h"
+
+int main(int argc, char** argv) {
+    DesignerApp app;
+    return app.run(argc, argv);
+}
+

--- a/apps/production/CMakeLists.txt
+++ b/apps/production/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(duke_production_app)
+
+add_executable(duke_production main.cpp ProductionApp.cpp)
+
+target_include_directories(duke_production PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/include
+    ${CMAKE_SOURCE_DIR}/DUKE/include
+    ${CMAKE_SOURCE_DIR}/finance/include
+)
+
+target_link_libraries(duke_production PRIVATE core duke finance)
+

--- a/apps/production/ProductionApp.cpp
+++ b/apps/production/ProductionApp.cpp
@@ -1,0 +1,54 @@
+#include "ProductionApp.h"
+#include <iostream>
+#include "ApplicationCore.h"
+
+ProductionApp::ProductionApp() : core_(new duke::ApplicationCore()) {
+    core_->carregarJSON();
+}
+
+ProductionApp::~ProductionApp() {
+    delete core_;
+}
+
+int ProductionApp::run(int argc, char** argv) {
+    if (argc < 2) {
+        showHelp();
+        return 0;
+    }
+    std::string command = argv[1];
+    std::vector<std::string> args(argv + 2, argv + argc);
+    if (command == "list-orders") {
+        handleListOrders();
+    } else if (command == "start-order") {
+        handleStartOrder(args);
+    } else if (command == "finish-order") {
+        handleFinishOrder(args);
+    } else {
+        std::cerr << "Unknown command: " << command << "\n";
+        showHelp();
+    }
+    return 0;
+}
+
+void ProductionApp::showHelp() const {
+    std::cout << "DUKE Production App Commands:\n";
+    std::cout << "  list-orders          List active production orders\n";
+    std::cout << "  start-order <id>     Start work on an order\n";
+    std::cout << "  finish-order <id>    Mark an order as complete\n";
+}
+
+void ProductionApp::handleListOrders() const {
+    std::cout << "Listing production orders...\n";
+    // TODO: Use core_ to load orders
+}
+
+void ProductionApp::handleStartOrder(const std::vector<std::string>& args) {
+    std::cout << "Starting order...\n";
+    // TODO: Start selected order and reserve materials
+}
+
+void ProductionApp::handleFinishOrder(const std::vector<std::string>& args) {
+    std::cout << "Finishing order...\n";
+    // TODO: Mark order as finished and update stock
+}
+

--- a/apps/production/ProductionApp.h
+++ b/apps/production/ProductionApp.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace duke {
+class ApplicationCore;
+}
+
+// ProductionApp encapsulates the CLI for the Production module.  It will
+// manage work orders, consume materials and register time spent.
+class ProductionApp {
+public:
+    ProductionApp();
+    ~ProductionApp();
+    int run(int argc, char** argv);
+
+private:
+    void showHelp() const;
+    void handleListOrders() const;
+    void handleStartOrder(const std::vector<std::string>& args);
+    void handleFinishOrder(const std::vector<std::string>& args);
+
+    duke::ApplicationCore* core_;
+};
+

--- a/apps/production/main.cpp
+++ b/apps/production/main.cpp
@@ -1,0 +1,7 @@
+#include "ProductionApp.h"
+
+int main(int argc, char** argv) {
+    ProductionApp app;
+    return app.run(argc, argv);
+}
+

--- a/apps/sales/CMakeLists.txt
+++ b/apps/sales/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(duke_sales_app)
+
+# Build the sales app.  It links against the core and finance libraries
+# defined in the existing project.  Adapt the path names to match the
+# actual location of these libraries in your repository.
+
+add_executable(duke_sales main.cpp SalesApp.cpp)
+
+target_include_directories(duke_sales PRIVATE
+    ${CMAKE_SOURCE_DIR}/core/include
+    ${CMAKE_SOURCE_DIR}/DUKE/include
+    ${CMAKE_SOURCE_DIR}/finance/include
+)
+
+target_link_libraries(duke_sales PRIVATE core duke finance)
+

--- a/apps/sales/SalesApp.cpp
+++ b/apps/sales/SalesApp.cpp
@@ -1,0 +1,57 @@
+#include "SalesApp.h"
+#include <iostream>
+
+#include "ApplicationCore.h" // Provided by the existing DUKE project
+
+SalesApp::SalesApp() : core_(new duke::ApplicationCore()) {
+    // Load materials and customers on startup
+    core_->carregarJSON();
+}
+
+SalesApp::~SalesApp() {
+    delete core_;
+}
+
+int SalesApp::run(int argc, char** argv) {
+    if (argc < 2) {
+        showHelp();
+        return 0;
+    }
+    std::string command = argv[1];
+    std::vector<std::string> args(argv + 2, argv + argc);
+
+    if (command == "new-order") {
+        handleNewOrder(args);
+    } else if (command == "list-customers") {
+        handleListCustomers();
+    } else if (command == "inventory") {
+        handleInventory();
+    } else {
+        std::cerr << "Unknown command: " << command << "\n";
+        showHelp();
+    }
+    return 0;
+}
+
+void SalesApp::showHelp() const {
+    std::cout << "DUKE Sales App Commands:\n";
+    std::cout << "  new-order <args>     Create a new sales order\n";
+    std::cout << "  list-customers       List all registered customers\n";
+    std::cout << "  inventory            Show stock of finished products\n";
+}
+
+void SalesApp::handleNewOrder(const std::vector<std::string>& args) {
+    // TODO: Implement order creation by interacting with ApplicationCore
+    std::cout << "Creating a new order...\n";
+}
+
+void SalesApp::handleListCustomers() const {
+    // TODO: Retrieve and display customers from ApplicationCore
+    std::cout << "Listing customers...\n";
+}
+
+void SalesApp::handleInventory() const {
+    // TODO: Show stock of finished products
+    std::cout << "Showing inventory...\n";
+}
+

--- a/apps/sales/SalesApp.h
+++ b/apps/sales/SalesApp.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// Forward declarations to avoid heavy includes.  The implementation will
+// include the necessary headers from the existing DUKE codebase (such as
+// ApplicationCore, Material, etc.).
+namespace duke {
+class ApplicationCore;
+}
+
+// SalesApp encapsulates the CLI for the Sales module.  It handles
+// customer management, order entry and stock checks for finished products.
+class SalesApp {
+public:
+    SalesApp();
+    ~SalesApp();
+
+    // Entry point.  Pass the command‑line arguments and dispatch the
+    // appropriate subcommands.
+    int run(int argc, char** argv);
+
+private:
+    // Implementation helpers
+    void showHelp() const;
+    void handleNewOrder(const std::vector<std::string>& args);
+    void handleListCustomers() const;
+    void handleInventory() const;
+
+    // Pointer to core application logic.  This object will be used to
+    // load materials, customers and persist changes.
+    duke::ApplicationCore* core_;
+};
+

--- a/apps/sales/main.cpp
+++ b/apps/sales/main.cpp
@@ -1,0 +1,7 @@
+#include "SalesApp.h"
+
+int main(int argc, char** argv) {
+    SalesApp app;
+    return app.run(argc, argv);
+}
+

--- a/include/production/ModeloProducao.h
+++ b/include/production/ModeloProducao.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+// Estruturas de modelo de produção (BOM) para representar produtos
+// compostos por várias partes e materiais.  Este cabeçalho define
+// classes básicas para registrar modelos de produção com subestruturas.
+
+namespace production {
+
+// Representa um item de material necessário para uma parte da produção.
+struct ItemMaterial {
+    std::string nome;
+    std::string unidade;  // ex.: "cm", "m", "unidade"
+    double quantidade;
+};
+
+// Representa um componente de um produto (por exemplo, Estrutura A,
+// Estrutura B).  Cada componente pode conter vários itens de material.
+struct Componente {
+    std::string nome;
+    std::vector<ItemMaterial> materiais;
+};
+
+// ModeloProducao descreve um produto completo com sua lista de
+// componentes.  Ele também armazena variantes (como tipos de tecido) e
+// observações para permitir ajustes sem alterar a definição base.
+class ModeloProducao {
+public:
+    ModeloProducao(const std::string& id, const std::string& nome);
+
+    void adicionarComponente(const Componente& comp);
+    const std::vector<Componente>& componentes() const;
+
+    // Definir uma variante para um campo (ex.: tecido = "Veludo Rose Gold").
+    void definirVariavel(const std::string& chave, const std::string& valor);
+    const std::string& variavel(const std::string& chave) const;
+
+private:
+    std::string id_;
+    std::string nome_;
+    std::vector<Componente> componentes_;
+    std::vector<std::pair<std::string, std::string>> variaveis_;
+};
+
+} // namespace production
+

--- a/src/production/ModeloProducao.cpp
+++ b/src/production/ModeloProducao.cpp
@@ -1,0 +1,30 @@
+#include "production/ModeloProducao.h"
+
+namespace production {
+
+ModeloProducao::ModeloProducao(const std::string& id, const std::string& nome)
+    : id_(id), nome_(nome) {}
+
+void ModeloProducao::adicionarComponente(const Componente& comp) {
+    componentes_.push_back(comp);
+}
+
+const std::vector<Componente>& ModeloProducao::componentes() const {
+    return componentes_;
+}
+
+void ModeloProducao::definirVariavel(const std::string& chave, const std::string& valor) {
+    variaveis_.emplace_back(chave, valor);
+}
+
+const std::string& ModeloProducao::variavel(const std::string& chave) const {
+    for (const auto& kv : variaveis_) {
+        if (kv.first == chave) {
+            return kv.second;
+        }
+    }
+    static const std::string empty;
+    return empty;
+}
+
+} // namespace production


### PR DESCRIPTION
## Summary
- Set up top-level CMake build for modular DUKE apps and add sub-apps for sales, production, admin, and designer.
- Implement placeholder CLI handlers for each new module.
- Introduce production `ModeloProducao` structures for Bills of Materials.

## Testing
- `make -C tests` *(fails: Qt6Widgets/QObject headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a510d1c7888327a4829a7f24aadad9