### PR TITLE
[sales] feat: add sales core interactions

### DIFF
--- a/DUKE/include/ApplicationCore.h
+++ b/DUKE/include/ApplicationCore.h
@@ -5,6 +5,8 @@
 #include "core/persist.h"
 #include "Material.h"
 #include "core.h"
+#include "Customer.h"
+#include "Order.h"
 
 namespace duke {
 
@@ -37,6 +39,34 @@ public:
     //   auto r = core.compararMateriais(mats, {0,1});
     std::vector<MaterialComparado> compararMateriais(const std::vector<Material>& mats,
                                                      const std::vector<int>& ids) const;
+
+    // ----- APIs do módulo de vendas -----
+    // Carrega materiais, clientes e pedidos usando os arquivos JSON padrão.
+    // Exemplo:
+    //   ApplicationCore core;
+    //   core.carregarJSON();
+    bool carregarJSON();
+
+    // Cria e persiste um novo pedido.
+    // Exemplo:
+    //   core.criarPedido("Ana", "Produto", 2);
+    bool criarPedido(const std::string& cliente, const std::string& item, int quantidade);
+
+    // Lista clientes cadastrados.
+    std::vector<Customer> listarClientes() const;
+
+    // Lista pedidos registrados.
+    std::vector<Order> listarPedidos() const;
+
+    // Consulta o estoque de materiais carregado.
+    std::vector<MaterialDTO> listarEstoque() const;
+
+private:
+    std::vector<MaterialDTO> base_;
+    std::vector<Material> mats_;
+    std::vector<Customer> clientes_;
+    std::vector<Order> pedidos_;
+    int nextId_ = 1;
 };
 
 } // namespace duke

--- a/DUKE/include/Customer.h
+++ b/DUKE/include/Customer.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <string>
+#include <nlohmann/json.hpp>
+
+namespace duke {
+
+// Representa um cliente do sistema de vendas.
+class Customer {
+public:
+    std::string nome; // nome do cliente
+
+    Customer() = default;
+    explicit Customer(const std::string& n);
+};
+
+// Serialização para JSON
+inline void to_json(nlohmann::json& j, const Customer& c) {
+    j = nlohmann::json{{"nome", c.nome}};
+}
+
+inline void from_json(const nlohmann::json& j, Customer& c) {
+    j.at("nome").get_to(c.nome);
+}
+
+} // namespace duke
+

--- a/DUKE/include/Order.h
+++ b/DUKE/include/Order.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+#include <nlohmann/json.hpp>
+
+namespace duke {
+
+// Representa um pedido simples de venda.
+class Order {
+public:
+    int id = 0;            // identificador do pedido
+    std::string cliente;   // nome do cliente
+    std::string item;      // produto solicitado
+    int quantidade = 0;    // quantidade de itens
+
+    Order() = default;
+    Order(int i, std::string c, std::string it, int q);
+};
+
+// Serialização para JSON
+inline void to_json(nlohmann::json& j, const Order& o) {
+    j = nlohmann::json{{"id", o.id}, {"cliente", o.cliente}, {"item", o.item}, {"quantidade", o.quantidade}};
+}
+
+inline void from_json(const nlohmann::json& j, Order& o) {
+    j.at("id").get_to(o.id);
+    j.at("cliente").get_to(o.cliente);
+    j.at("item").get_to(o.item);
+    j.at("quantidade").get_to(o.quantidade);
+}
+
+} // namespace duke
+

--- a/DUKE/src/Customer.cpp
+++ b/DUKE/src/Customer.cpp
@@ -1,0 +1,8 @@
+#include "Customer.h"
+
+namespace duke {
+
+Customer::Customer(const std::string& n) : nome(n) {}
+
+} // namespace duke
+

--- a/DUKE/src/Order.cpp
+++ b/DUKE/src/Order.cpp
@@ -1,0 +1,9 @@
+#include "Order.h"
+
+namespace duke {
+
+Order::Order(int i, std::string c, std::string it, int q)
+    : id(i), cliente(std::move(c)), item(std::move(it)), quantidade(q) {}
+
+} // namespace duke
+

--- a/apps/sales/SalesApp.cpp
+++ b/apps/sales/SalesApp.cpp
@@ -41,17 +41,30 @@ void SalesApp::showHelp() const {
 }
 
 void SalesApp::handleNewOrder(const std::vector<std::string>& args) {
-    // TODO: Implement order creation by interacting with ApplicationCore
-    std::cout << "Creating a new order...\n";
+    // Espera: new-order <cliente> <item> <quantidade>
+    if (args.size() < 3) {
+        std::cerr << "Uso: new-order <cliente> <item> <quantidade>\n";
+        return;
+    }
+    int qtd = std::stoi(args[2]);
+    if (core_->criarPedido(args[0], args[1], qtd)) {
+        std::cout << "Pedido criado com sucesso.\n";
+    } else {
+        std::cerr << "Falha ao criar pedido.\n";
+    }
 }
 
 void SalesApp::handleListCustomers() const {
-    // TODO: Retrieve and display customers from ApplicationCore
-    std::cout << "Listing customers...\n";
+    auto clientes = core_->listarClientes();
+    for (const auto& c : clientes) {
+        std::cout << "- " << c.nome << "\n";
+    }
 }
 
 void SalesApp::handleInventory() const {
-    // TODO: Show stock of finished products
-    std::cout << "Showing inventory...\n";
+    auto estoque = core_->listarEstoque();
+    for (const auto& m : estoque) {
+        std::cout << "- " << m.nome << " (R$" << m.valor << ")\n";
+    }
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -11,17 +11,16 @@ CALC_SRCS := $(wildcard duke/*.cpp)
 CORE_SRCS := $(wildcard core/*.cpp)
 FIN_SRCS := $(wildcard finance/*.cpp)
 FIN_LIB_SRCS := $(wildcard ../src/finance/*.cpp)
+SALES_SRCS := $(wildcard sales/*.cpp)
 
-.PHONY: all duke core finance clean
-all: duke core finance
+.PHONY: all duke core finance sales clean
+all: duke core finance sales
 
 duke: $(LIB_CALC) $(LIB_CORE)
 ifeq ($(strip $(CALC_SRCS)),)
 	@echo "No DUKE tests"
 else
-	$(CXX) $(CXXFLAGS) -include duke/namespace.h \
-		$(CALC_SRCS) -I$(CALC_DIR)/include -I../include -I../third_party -I$(CORE_DIR)/include \
-		$(LIB_CALC) $(LIB_CORE) -o duke/run_tests
+	$(CXX) $(CXXFLAGS) -include duke/namespace.h $(CALC_SRCS) -I$(CALC_DIR)/include -I../include -I../third_party -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) -o duke/run_tests
 	./duke/run_tests
 endif
 
@@ -29,8 +28,7 @@ core: $(LIB_CORE)
 ifeq ($(strip $(CORE_SRCS)),)
 	@echo "No core tests"
 else
-	$(CXX) $(CXXFLAGS) $(CORE_SRCS) -I$(CORE_DIR)/include \
-		$(LIB_CORE) -o core/run_tests
+	$(CXX) $(CXXFLAGS) $(CORE_SRCS) -I$(CORE_DIR)/include $(LIB_CORE) -o core/run_tests
 	./core/run_tests
 endif
 
@@ -42,6 +40,14 @@ else
 	./finance/run_tests
 endif
 
+sales: $(LIB_CALC) $(LIB_CORE)
+ifeq ($(strip $(SALES_SRCS)),)
+	@echo "No sales tests"
+else
+	$(CXX) $(CXXFLAGS) $(SALES_SRCS) -I$(CALC_DIR)/include -I../include -I../third_party -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) -o sales/run_tests
+	./sales/run_tests
+endif
+
 $(LIB_CALC):
 	$(MAKE) -C $(CALC_DIR) libduke.a
 
@@ -49,4 +55,4 @@ $(LIB_CORE):
 	$(MAKE) -C $(CORE_DIR) libcore.a
 
 clean:
-	rm -f duke/run_tests core/run_tests finance/run_tests
+	rm -f duke/run_tests core/run_tests finance/run_tests sales/run_tests

--- a/tests/sales/run_tests.cpp
+++ b/tests/sales/run_tests.cpp
@@ -1,0 +1,10 @@
+void test_criar_pedido();
+void test_listar_clientes();
+void test_consulta_estoque();
+
+int main() {
+    test_criar_pedido();
+    test_listar_clientes();
+    test_consulta_estoque();
+    return 0;
+}

--- a/tests/sales/sales_core_test.cpp
+++ b/tests/sales/sales_core_test.cpp
@@ -1,0 +1,55 @@
+#include "ApplicationCore.h"
+#include "core/persist.h"
+#include <filesystem>
+#include <vector>
+#include <cassert>
+
+// Testa criação de pedido
+void test_criar_pedido() {
+    using namespace duke;
+    std::filesystem::remove_all("tmp_sales");
+    Persist::Config cfg; cfg.baseDir = "tmp_sales"; Persist::setConfig(cfg);
+    std::vector<MaterialDTO> mats{{"Prod", 10.0, 1.0, 1.0, "linear"}};
+    Persist::saveJSON("materiais.json", mats);
+    std::vector<Customer> clientes{Customer{"Ana"}};
+    Persist::saveJSONVec("clientes.json", clientes, "clientes");
+
+    ApplicationCore core;
+    core.carregarJSON();
+    assert(core.criarPedido("Ana", "Prod", 1));
+    auto pedidos = core.listarPedidos();
+    assert(pedidos.size() == 1);
+    assert(pedidos[0].cliente == "Ana");
+    std::filesystem::remove_all("tmp_sales");
+}
+
+// Testa listagem de clientes
+void test_listar_clientes() {
+    using namespace duke;
+    std::filesystem::remove_all("tmp_sales_cli");
+    Persist::Config cfg; cfg.baseDir = "tmp_sales_cli"; Persist::setConfig(cfg);
+    std::vector<Customer> clientes{Customer{"Bia"}, Customer{"Carlos"}};
+    Persist::saveJSONVec("clientes.json", clientes, "clientes");
+    Persist::saveJSON("materiais.json", std::vector<MaterialDTO>{{"X",1,1,1,"linear"}});
+
+    ApplicationCore core; core.carregarJSON();
+    auto lista = core.listarClientes();
+    assert(lista.size() == 2);
+    assert(lista[0].nome == "Bia");
+    std::filesystem::remove_all("tmp_sales_cli");
+}
+
+// Testa consulta de estoque
+void test_consulta_estoque() {
+    using namespace duke;
+    std::filesystem::remove_all("tmp_sales_inv");
+    Persist::Config cfg; cfg.baseDir = "tmp_sales_inv"; Persist::setConfig(cfg);
+    std::vector<MaterialDTO> mats{{"Estoque", 5.0, 1.0, 1.0, "linear"}};
+    Persist::saveJSON("materiais.json", mats);
+
+    ApplicationCore core; core.carregarJSON();
+    auto estoque = core.listarEstoque();
+    assert(estoque.size() == 1);
+    assert(estoque[0].nome == "Estoque");
+    std::filesystem::remove_all("tmp_sales_inv");
+}


### PR DESCRIPTION
## Summary
- implement customer and order entities with persistence
- expose sales APIs in ApplicationCore and SalesApp
- add tests for creating orders, listing customers and checking inventory

## Testing
- `make -C tests` *(fails: Package 'Qt6Widgets' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a513dbc2f8832790849a8a658f1946