### PR TITLE
Add core notification service and integrate with apps

### DIFF
--- a/apps/admin/AdminApp.cpp
+++ b/apps/admin/AdminApp.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include "finance/Repo.h"
 #include "finance/SupplierRepo.h"
+#include <chrono>
 
 AdminApp::AdminApp() : repo_(new finance::FinanceRepo()) {
     repo_->load();
@@ -30,6 +31,10 @@ int AdminApp::run(int argc, char** argv) {
     } else {
         std::cerr << "Unknown command: " << command << "\n";
         showHelp();
+    }
+    auto alerts = notifications_.dueAlerts(std::chrono::system_clock::now());
+    for (const auto& a : alerts) {
+        std::cout << "Alerta: entrega vencida para " << a << "\n";
     }
     return 0;
 }
@@ -105,5 +110,10 @@ void AdminApp::handleSuppliers() const {
     for (const auto& s : srepo.all()) {
         std::cout << s.id << " " << s.nome << "\n";
     }
+}
+
+void AdminApp::addDeliveryDate(const std::string& id,
+                               std::chrono::system_clock::time_point due) {
+    notifications_.addDelivery(id, due);
 }
 

--- a/apps/admin/AdminApp.h
+++ b/apps/admin/AdminApp.h
@@ -2,6 +2,8 @@
 
 #include <string>
 #include <vector>
+#include <chrono>
+#include "core/notifications.h"
 
 namespace finance {
 class FinanceRepo;
@@ -15,6 +17,9 @@ public:
     ~AdminApp();
     int run(int argc, char** argv);
 
+    void addDeliveryDate(const std::string& id,
+                         std::chrono::system_clock::time_point due);
+
 private:
     void showHelp() const;
     void handleAddTransaction(const std::vector<std::string>& args);
@@ -23,5 +28,6 @@ private:
     void handleSuppliers() const;
 
     finance::FinanceRepo* repo_;
+    core::NotificationService notifications_;
 };
 

--- a/apps/production/ProductionApp.cpp
+++ b/apps/production/ProductionApp.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <algorithm>
 #include "ApplicationCore.h"
+#include <chrono>
 
 ProductionApp::ProductionApp() : core_(new duke::ApplicationCore()) {
     // Carrega dados básicos (stubbed na versão de testes)
@@ -56,6 +57,10 @@ int ProductionApp::run(int argc, char** argv) {
     } else {
         std::cerr << "Unknown command: " << command << "\n";
         showHelp();
+    }
+    auto alerts = notifications_.dueAlerts(std::chrono::system_clock::now());
+    for (const auto& a : alerts) {
+        std::cout << "Alerta: entrega vencida para " << a << "\n";
     }
     return 0;
 }
@@ -140,5 +145,10 @@ void ProductionApp::handleFinishOrder(const std::vector<std::string>& args) {
     }
     ord.finished = true;
     std::cout << "Order " << ord.id << " finished\n";
+}
+
+void ProductionApp::addDeliveryDate(const std::string& id,
+                                    std::chrono::system_clock::time_point due) {
+    notifications_.addDelivery(id, due);
 }
 

--- a/apps/production/ProductionApp.h
+++ b/apps/production/ProductionApp.h
@@ -3,7 +3,9 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <chrono>
 #include "production/ModeloProducao.h"
+#include "core/notifications.h"
 
 namespace duke {
 class ApplicationCore;
@@ -16,6 +18,9 @@ public:
     ProductionApp();
     ~ProductionApp();
     int run(int argc, char** argv);
+
+    void addDeliveryDate(const std::string& id,
+                         std::chrono::system_clock::time_point due);
 
 private:
     void showHelp() const;
@@ -35,5 +40,6 @@ private:
     std::vector<production::ModeloProducao> modelos_;
     std::vector<ProductionOrder> orders_;
     std::map<std::string, double> estoque_;
+    core::NotificationService notifications_;
 };
 

--- a/apps/sales/SalesApp.cpp
+++ b/apps/sales/SalesApp.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 
 #include "ApplicationCore.h" // Provided by the existing DUKE project
+#include <chrono>
 
 SalesApp::SalesApp() : core_(new duke::ApplicationCore()) {
     // Load materials and customers on startup
@@ -29,6 +30,10 @@ int SalesApp::run(int argc, char** argv) {
     } else {
         std::cerr << "Unknown command: " << command << "\n";
         showHelp();
+    }
+    auto alerts = notifications_.dueAlerts(std::chrono::system_clock::now());
+    for (const auto& a : alerts) {
+        std::cout << "Alerta: entrega vencida para " << a << "\n";
     }
     return 0;
 }
@@ -66,5 +71,10 @@ void SalesApp::handleInventory() const {
     for (const auto& m : estoque) {
         std::cout << "- " << m.nome << " (R$" << m.valor << ")\n";
     }
+}
+
+void SalesApp::addDeliveryDate(const std::string& id,
+                               std::chrono::system_clock::time_point due) {
+    notifications_.addDelivery(id, due);
 }
 

--- a/apps/sales/SalesApp.h
+++ b/apps/sales/SalesApp.h
@@ -2,6 +2,8 @@
 
 #include <string>
 #include <vector>
+#include <chrono>
+#include "core/notifications.h"
 
 // Forward declarations to avoid heavy includes.  The implementation will
 // include the necessary headers from the existing DUKE codebase (such as
@@ -21,6 +23,9 @@ public:
     // appropriate subcommands.
     int run(int argc, char** argv);
 
+    void addDeliveryDate(const std::string& id,
+                         std::chrono::system_clock::time_point due);
+
 private:
     // Implementation helpers
     void showHelp() const;
@@ -31,5 +36,6 @@ private:
     // Pointer to core application logic.  This object will be used to
     // load materials, customers and persist changes.
     duke::ApplicationCore* core_;
+    core::NotificationService notifications_;
 };
 

--- a/core/include/core/notifications.h
+++ b/core/include/core/notifications.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <chrono>
+
+namespace core {
+
+struct DeliveryInfo {
+    std::string id;
+    std::chrono::system_clock::time_point due;
+    bool alerted = false;
+};
+
+class NotificationService {
+public:
+    void addDelivery(const std::string& id,
+                     const std::chrono::system_clock::time_point& due);
+    std::vector<std::string> dueAlerts(const std::chrono::system_clock::time_point& now);
+
+private:
+    std::vector<DeliveryInfo> deliveries_;
+};
+
+} // namespace core
+

--- a/core/src/notifications.cpp
+++ b/core/src/notifications.cpp
@@ -1,0 +1,23 @@
+#include "core/notifications.h"
+
+namespace core {
+
+void NotificationService::addDelivery(const std::string& id,
+                                      const std::chrono::system_clock::time_point& due) {
+    deliveries_.push_back({id, due, false});
+}
+
+std::vector<std::string> NotificationService::dueAlerts(
+        const std::chrono::system_clock::time_point& now) {
+    std::vector<std::string> alerts;
+    for (auto& d : deliveries_) {
+        if (!d.alerted && d.due <= now) {
+            alerts.push_back(d.id);
+            d.alerted = true;
+        }
+    }
+    return alerts;
+}
+
+} // namespace core
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -49,15 +49,16 @@ else
 endif
   
   # --- Alvos unitários -------------------------------------------------
-production:
+production: $(LIB_CORE)
 ifeq ($(strip $(PROD_SRCS)),)
-	@echo "No production tests"
+		@echo "No production tests"
 else
-	@mkdir -p production
-	$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) \
-		-Iproduction -I.. -I../include \
+		@mkdir -p production
+		$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) \
+		-Iproduction -I.. -I../include -I../core/include \
+		$(LIB_CORE) \
 		-o production/run_tests
-	./production/run_tests
+		./production/run_tests
 endif
 
 sales: $(LIB_CALC) $(LIB_CORE)
@@ -73,12 +74,12 @@ else
 endif
 
 
-admin:
+admin: $(LIB_CORE)
 ifeq ($(strip $(ADMIN_SRCS)),)
-	@echo "No admin tests"
+		@echo "No admin tests"
 else
-	$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../third_party -I../core/include -o admin/run_tests
-	./admin/run_tests
+		$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../third_party -I../core/include $(LIB_CORE) -o admin/run_tests
+		./admin/run_tests
 endif
 
 designer:

--- a/tests/core/notifications_test.cpp
+++ b/tests/core/notifications_test.cpp
@@ -1,0 +1,12 @@
+#include "core/notifications.h"
+#include <cassert>
+#include <chrono>
+
+void test_overdue_alert() {
+    core::NotificationService service;
+    auto now = std::chrono::system_clock::now();
+    service.addDelivery("pedido1", now - std::chrono::hours(24));
+    auto alerts = service.dueAlerts(now);
+    assert(alerts.size() == 1);
+    assert(alerts[0] == "pedido1");
+}

--- a/tests/core/run_tests.cpp
+++ b/tests/core/run_tests.cpp
@@ -1,0 +1,6 @@
+void test_overdue_alert();
+
+int main() {
+    test_overdue_alert();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add core notifications module to track delivery deadlines and issue alerts
- integrate notification service with Sales, Production and Admin apps
- cover overdue delivery alerts with unit test

## Testing
- `make core production admin`
- `make core production sales admin` *(fails: Package Qt6Core/Qt6Widgets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a51a964dcc832781322b66c449e0f5