### PR TITLE
fix: update DUKE path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
+---
 name: CI
 
-on:
+'on':
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
@@ -11,7 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -19,11 +19,11 @@ jobs:
 
       - name: Build
         run: |
-          cd DUKE
+          cd third_party/DUKE
           g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app
 
       - name: Test
         run: |
-          cd DUKE
+          cd third_party/DUKE
           make -C tests
           ./tests/run_tests


### PR DESCRIPTION
## Summary
- point build and test steps to `third_party/DUKE` in CI workflow
- tidy workflow YAML to satisfy linting

## Testing
- `yamllint .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68a52a1d5ce48327aa6e1cf6f9eeb730