### PR TITLE
Install Qt6 packages and verify with pkg-config in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ make nlohmann-json3-dev
+          sudo apt-get install -y g++ make nlohmann-json3-dev qt6-base-dev
+          pkg-config --modversion Qt6Core
 
       - name: Build
         run: |


### PR DESCRIPTION
## Summary
- Install Qt6 base development package during CI dependency setup
- Verify Qt6 availability with `pkg-config`

## Testing
- `make -C tests` *(fails: include/core/persist.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a52a434f688327adf7c7c31021c392