### PR TITLE
[ci] chore: run full test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,14 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y g++ make nlohmann-json3-dev
+          sudo apt-get install -y g++ make nlohmann-json3-dev qt6-base-dev
 
-      - name: Build
+      - name: Build core and DUKE
         run: |
-          cd DUKE
-          g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app
+          make -C core
+          make -C third_party/DUKE
 
       - name: Test
         run: |
-          cd DUKE
           make -C tests
           ./tests/run_tests

--- a/tests/run_tests
+++ b/tests/run_tests
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# iterate over subdirectories inside tests and run their test binaries if present
+for test_bin in "$(dirname "$0")"/*/run_tests; do
+  if [ -x "$test_bin" ]; then
+    "$test_bin"
+  fi
+done


### PR DESCRIPTION
## Summary
- build core and third_party/DUKE before running tests
- run full test suite via `make -C tests` and `tests/run_tests`

## Testing
- `make -C core` *(fails: finance/Repo.h not found)*
- `make -C third_party/DUKE` *(fails: core/persist.h not found)*
- `make -C tests` *(fails: Qt6Widgets.pc not found)*
- `./tests/run_tests`

### 📝 Checklist deste PR
- [x] Revisão de código
- [ ] Testes adicionados e rodando
- [ ] Documentação atualizada
- [ ] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a52a4e556c8327a7678d7d4ec44278