### PR TITLE
Update DUKE paths and include directories

### DIFF
--- a/src/duke/Makefile
+++ b/src/duke/Makefile
@@ -1,0 +1,37 @@
+CXX = g++
+CXXFLAGS = -std=c++17 -Wall -fPIC
+CORE_DIR = ../../core
+INCLUDES = -I../../include -I../../include/duke -I../../third_party -I$(CORE_DIR)/include
+QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets 2>/dev/null)
+QT_LIBS := $(shell pkg-config --libs Qt6Widgets 2>/dev/null)
+CXXFLAGS += $(QT_CFLAGS)
+
+CORE_LIB = $(CORE_DIR)/libcore.a
+
+CLI_SRC := cli/app.cpp cli/args.cpp cli/parser.cpp cli/utils.cpp cli/commands.cpp
+FIN_SRC := $(wildcard ../finance/*.cpp)
+SRC := $(wildcard *.cpp) $(CLI_SRC)        $(wildcard domain/*.cpp) $(wildcard custo/*.cpp)        $(wildcard ui/*.cpp) $(FIN_SRC)
+LIB_SRC := $(filter-out main.cpp,$(SRC))
+OBJ := $(LIB_SRC:.cpp=.o)
+
+all: libduke.a libduke.so
+
+libduke.a: $(OBJ) $(CORE_LIB)
+	ar rcs $@ $(OBJ)
+
+libduke.so: $(OBJ) $(CORE_LIB)
+	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(QT_LIBS) -L$(CORE_DIR) -lcore -o $@
+
+%.o: %.cpp
+	@mkdir -p $(dir $@)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
+
+cli: libduke.a $(CORE_LIB) main.cpp
+	$(CXX) $(CXXFLAGS) main.cpp $(INCLUDES) -L. -lduke -L$(CORE_DIR) -lcore $(QT_LIBS) -o app
+
+.PHONY: clean cli
+clean:
+	rm -f $(OBJ) libduke.a libduke.so app
+
+$(CORE_LIB):
+	$(MAKE) -C $(CORE_DIR)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,7 +2,7 @@ CXX = g++
 CXXFLAGS = -std=c++17 -Wall -DUNIT_TEST
 
 CORE_DIR = ../core
-CALC_DIR = ../third_party/DUKE
+CALC_DIR = ../src/duke
 
 LIB_CORE = $(CORE_DIR)/libcore.a
 LIB_CALC = $(CALC_DIR)/libduke.a
@@ -28,7 +28,7 @@ duke: $(LIB_CALC) $(LIB_CORE)
 ifeq ($(strip $(CALC_SRCS)),)
         @echo "No DUKE tests"
 else
-	$(CXX) $(CXXFLAGS) -include duke/namespace.h $(CALC_SRCS) -I../include -I../third_party -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) -o duke/run_tests
+	$(CXX) $(CXXFLAGS) -include duke/namespace.h $(CALC_SRCS) -I../include -I../include/duke -I../third_party -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) -o duke/run_tests
 	./duke/run_tests
 endif
 
@@ -44,7 +44,7 @@ finance:
 ifeq ($(strip $(FIN_SRCS)),)
 	@echo "No finance tests"
 else
-	$(CXX) $(CXXFLAGS) $(FIN_SRCS) $(FIN_LIB_SRCS) -I../include -I../third_party -I../core/include -o finance/run_tests
+	$(CXX) $(CXXFLAGS) $(FIN_SRCS) $(FIN_LIB_SRCS) -I../include -I../include/duke -I../third_party -I../core/include -o finance/run_tests
 	./finance/run_tests
 endif
   
@@ -55,7 +55,7 @@ ifeq ($(strip $(PROD_SRCS)),)
 else
 		@mkdir -p production
 		$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) \
-		-Iproduction -I.. -I../include -I../core/include \
+		-Iproduction -I.. -I../include -I../include/duke -I../core/include \
 		$(LIB_CORE) \
 		-o production/run_tests
 		./production/run_tests
@@ -67,7 +67,7 @@ ifeq ($(strip $(SALES_SRCS)),)
 else
 	@mkdir -p sales
 	$(CXX) $(CXXFLAGS) $(SALES_SRCS) \
-	-I../include -I../third_party -I$(CORE_DIR)/include \
+	-I../include -I../include/duke -I../third_party -I$(CORE_DIR)/include \
 	$(LIB_CALC) $(LIB_CORE) \
 	-o sales/run_tests
 	./sales/run_tests
@@ -78,7 +78,7 @@ admin: $(LIB_CORE)
 ifeq ($(strip $(ADMIN_SRCS)),)
 		@echo "No admin tests"
 else
-		$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../third_party -I../core/include $(LIB_CORE) -o admin/run_tests
+		$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../include/duke -I../third_party -I../core/include $(LIB_CORE) -o admin/run_tests
 		./admin/run_tests
 endif
 
@@ -87,7 +87,7 @@ ifeq ($(strip $(DES_SRCS)),)
 	@echo "No designer tests"
 else
 	$(CXX) $(CXXFLAGS) $(DES_SRCS) ../apps/designer/DesignerApp.cpp $(PROD_LIB_SRCS) \
-	-I../apps/designer -I../include -I../third_party -o designer/run_tests
+	-I../apps/designer -I../include -I../include/duke -I../third_party -o designer/run_tests
 	./designer/run_tests
 endif
 
@@ -99,3 +99,4 @@ $(LIB_CORE):
 
 clean:
 	rm -f duke/run_tests core/run_tests finance/run_tests designer/run_tests admin/run_tests production/run_tests sales/run_tests
+


### PR DESCRIPTION
## Summary
- point tests to new `src/duke` and `include/duke` paths
- add Makefile under `src/duke` for building DUKE library

## Testing
- `make` *(fails: undefined reference to duke::gui symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68a53750171c8327838a75da6a2f1568