### PR TITLE
refactor: update DUKE build references

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,12 @@ make
 ### Módulo principal `DUKE`
 
 ```sh
-cd third_party/DUKE
+cd src/duke
 make
 # opcional: gerar CLI
 make cli
-# opcional: gerar GUI
-make gui
-# executar GUI
-./app_gui
+# executar CLI
+./app
 ```
 
 ## Documentação

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -4,9 +4,9 @@ Visão geral dos principais componentes do DUKE.
 
 ## Núcleo do aplicativo
 Responsável pela lógica de comparação e pelos cálculos de cortes e materiais.
-Principais arquivos:
-- `third_party/DUKE/app.cpp`
-- `third_party/DUKE/include/duke.hpp`
+ Principais arquivos:
+ - `src/duke/ApplicationCore.cpp`
+ - `include/duke/duke.hpp`
 
 ## Persistência de dados
 Centraliza leitura e escrita de informações em JSON ou CSV, além das
@@ -14,13 +14,13 @@ configurações de execução. Antes de salvar, cada `MaterialDTO` é
 validado: o nome não pode ser vazio e nenhum valor numérico pode ser
 negativo. Caso algum item seja inválido, a operação é abortada e um
 aviso em vermelho é emitido.
-Principais arquivos:
-- `third_party/DUKE/persist.h`
+ Principais arquivos:
+ - `include/duke/persist.hpp`
 
 ## Interface de linha de comando
 Ponto de entrada do programa e interação com o usuário via terminal.
-Principais arquivos:
-- `third_party/DUKE/main.cpp`
+ Principais arquivos:
+ - `src/duke/main.cpp`
 
 ## Testes automatizados
 Previsto para reunir casos de teste que validem comparações e rotinas de

--- a/docs/REVISIONS.md
+++ b/docs/REVISIONS.md
@@ -2,12 +2,12 @@
 
 1. Separar a lógica do app em módulos
    - Motivação: Facilitar manutenção, testes e reutilização.
-   - Arquivos impactados: `third_party/DUKE/app.cpp`, `third_party/DUKE/include/duke.hpp`, `third_party/DUKE/main.cpp`.
+    - Arquivos impactados: `src/duke/ApplicationCore.cpp`, `include/duke/duke.hpp`, `src/duke/main.cpp`.
 
 2. Validar dados antes de salvar
    - Motivação: Garantir integridade das informações e evitar erros ao persistir dados.
-   - Arquivos impactados: `third_party/DUKE/app.cpp`, `third_party/DUKE/persist.h`, arquivos em `third_party/DUKE/data/`.
+    - Arquivos impactados: `src/duke/ApplicationCore.cpp`, `include/duke/persist.hpp`.
 
 3. Adicionar opções de CLI
    - Motivação: Permitir que o usuário configure operações e parâmetros do DUKE.
-   - Arquivos impactados: `third_party/DUKE/main.cpp`, `third_party/DUKE/app.cpp`.
+    - Arquivos impactados: `src/duke/main.cpp`, `src/duke/cli/app.cpp`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,10 +4,10 @@ O DUKE evoluirá em etapas para oferecer mais flexibilidade e confiabilidade.
 
 ## Módulos planejados
 
-- **Núcleo do aplicativo** (`third_party/DUKE/app.cpp`)
+- **Núcleo do aplicativo** (`src/duke/ApplicationCore.cpp`)
   - Extrair a lógica de comparação e seleção de materiais em funções reutilizáveis.
   - Preparar o arquivo para futura divisão em múltiplos módulos.
-- **Persistência de dados** (`third_party/DUKE/persist.h`)
+- **Persistência de dados** (`include/duke/persist.hpp`)
   - Centralizar leitura/escrita em formatos adicionais (ex.: XML).
   - Integrar validação de dados antes de salvar. ✅
   - Suporte a serialização de planos de corte (CorteDTO e PlanoCorteDTO). ✅
@@ -16,12 +16,12 @@ O DUKE evoluirá em etapas para oferecer mais flexibilidade e confiabilidade.
   - Índice global de planos com atualização atômica (`updateIndex`). ✅
   - Persistência automática de planos gerados com `makeId`, `outPlanosDirFor`, `savePlanoJSON/CSV` e `updateIndex`. ✅
   - Tratamento de falhas na gravação de planos, abortando o fluxo e avisando o usuário. ✅
-- **Interface de linha de comando** (`third_party/DUKE/main.cpp`)
+- **Interface de linha de comando** (`src/duke/main.cpp`)
   - Adicionar opções de ajuda e parâmetros para cálculos automatizados. ✅
   - Melhorar mensagens de erro para entradas inválidas.
   - Suporte inicial a `--projeto` e registro dos comandos `abrir`, `listar` e `comparar`. ✅
   - Modularizar CLI em `parser`, `commands` e utilitários. ✅
-- **Interface gráfica básica** (`third_party/DUKE/gui/MainWindow`)
+- **Interface gráfica básica** (`src/duke/gui/MainWindow`)
   - Janela principal com botão para selecionar material. ✅
 - **Financeiro** (`fin add|list|sum`)
   - CLI para registrar, listar e somar lançamentos com filtros. ✅

--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -16,18 +16,12 @@ if not exist "%VSCODE_DIR%\tasks.json" (
         echo         {
         echo             "label": "build",
         echo             "type": "shell",
-        echo             "command": "g++",
+        echo             "command": "make",
         echo             "args": [
-        echo                 "-std=c++17",
-        echo                 "-Wall",
-        echo                 "src/*.cpp",
-        echo                 "-Iinclude",
-        echo                 "-I../third_party",
-        echo                 "-o",
-        echo                 "app"
+        echo                 "cli"
         echo             ],
         echo             "options": {
-        echo                 "cwd": "${workspaceFolder}/third_party/DUKE"
+        echo                 "cwd": "${workspaceFolder}/src/duke"
         echo             },
         echo             "group": "build",
         echo             "problemMatcher": [
@@ -48,10 +42,10 @@ if not exist "%VSCODE_DIR%\launch.json" (
         echo             "name": "Debug app",
         echo             "type": "cppdbg",
         echo             "request": "launch",
-        echo             "program": "${workspaceFolder}/third_party/DUKE/app",
+        echo             "program": "${workspaceFolder}/src/duke/app",
         echo             "args": [],
         echo             "stopAtEntry": false,
-        echo             "cwd": "${workspaceFolder}/third_party/DUKE",
+        echo             "cwd": "${workspaceFolder}/src/duke",
         echo             "environment": [],
         echo             "externalConsole": false,
         echo             "MIMode": "gdb",
@@ -85,4 +79,3 @@ if not exist "%VSCODE_DIR%\c_cpp_properties.json" (
 )
 
 echo VSCode configuration created.
-


### PR DESCRIPTION
## Summary
- update build docs to use integrated `src/duke` module
- remove old third_party/DUKE references across docs
- adjust VSCode helper script to call new module

## Testing
- `timeout 100 make -C src/duke cli` (fails: undefined reference to Qt6 and gui symbols)
- `timeout 100 make -C tests` (interrupted during compilation)


------
https://chatgpt.com/codex/tasks/task_e_68a53a7c534c8327843da3964fa32c3d