### PR TITLE
Specify nlohmann include path for Duke build

### DIFF
--- a/src/duke/Makefile
+++ b/src/duke/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -Wall -fPIC
 CORE_DIR = ../../core
-INCLUDES = -I../../include -I../../include/duke -I../../third_party -I$(CORE_DIR)/include
+INCLUDES = -I../../include -I../../include/duke -I../../third_party/nlohmann -I$(CORE_DIR)/include
 QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets 2>/dev/null)
 QT_LIBS := $(shell pkg-config --libs Qt6Widgets 2>/dev/null)
 CXXFLAGS += $(QT_CFLAGS)

--- a/third_party/nlohmann/nlohmann/json.hpp
+++ b/third_party/nlohmann/nlohmann/json.hpp
@@ -1,0 +1,2 @@
+#include "../json.hpp"
+


### PR DESCRIPTION
## Summary
- Narrow Duke Makefile include path to the nlohmann headers instead of the entire third_party tree
- Add forwarding header to expose nlohmann json via the new include directory

## Testing
- `make -C src/duke clean && make -C src/duke`


------
https://chatgpt.com/codex/tasks/task_e_68a53fb41a788327a7cab065b77b248f