### PR TITLE
Refine third-party includes in test build

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,7 @@ duke: $(LIB_CALC) $(LIB_CORE)
 ifeq ($(strip $(CALC_SRCS)),)
         @echo "No DUKE tests"
 else
-	$(CXX) $(CXXFLAGS) -include duke/namespace.h $(CALC_SRCS) -I../include -I../include/duke -I../third_party -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) -o duke/run_tests
+	$(CXX) $(CXXFLAGS) -include duke/namespace.h $(CALC_SRCS) -I../include -I../include/duke -I../third_party/nlohmann -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) -o duke/run_tests
 	./duke/run_tests
 endif
 
@@ -36,7 +36,7 @@ core: $(LIB_CORE)
 ifeq ($(strip $(CORE_SRCS)),)
 	@echo "No core tests"
 else
-	$(CXX) $(CXXFLAGS) $(CORE_SRCS) -I$(CORE_DIR)/include -I../third_party $(LIB_CORE) -o core/run_tests
+	$(CXX) $(CXXFLAGS) $(CORE_SRCS) $(FIN_LIB_SRCS) -I$(CORE_DIR)/include -I../include -I../third_party/nlohmann $(LIB_CORE) -o core/run_tests
 	./core/run_tests
 endif
 
@@ -44,21 +44,21 @@ finance:
 ifeq ($(strip $(FIN_SRCS)),)
 	@echo "No finance tests"
 else
-	$(CXX) $(CXXFLAGS) $(FIN_SRCS) $(FIN_LIB_SRCS) -I../include -I../include/duke -I../third_party -I../core/include -o finance/run_tests
+	$(CXX) $(CXXFLAGS) $(FIN_SRCS) $(FIN_LIB_SRCS) -I../include -I../include/duke -I../third_party/nlohmann -I../core/include -o finance/run_tests
 	./finance/run_tests
 endif
   
   # --- Alvos unitários -------------------------------------------------
 production: $(LIB_CORE)
 ifeq ($(strip $(PROD_SRCS)),)
-		@echo "No production tests"
+	@echo "No production tests"
 else
-		@mkdir -p production
-		$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) \
-		-Iproduction -I.. -I../include -I../include/duke -I../core/include \
-		$(LIB_CORE) \
-		-o production/run_tests
-		./production/run_tests
+	@mkdir -p production
+	$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) \
+	-Iproduction -I.. -I../include -I../include/duke -I../core/include \
+	$(LIB_CORE) \
+	-o production/run_tests
+	./production/run_tests
 endif
 
 sales: $(LIB_CALC) $(LIB_CORE)
@@ -67,7 +67,7 @@ ifeq ($(strip $(SALES_SRCS)),)
 else
 	@mkdir -p sales
 	$(CXX) $(CXXFLAGS) $(SALES_SRCS) \
-	-I../include -I../include/duke -I../third_party -I$(CORE_DIR)/include \
+	-I../include -I../include/duke -I../third_party/nlohmann -I$(CORE_DIR)/include \
 	$(LIB_CALC) $(LIB_CORE) \
 	-o sales/run_tests
 	./sales/run_tests
@@ -76,10 +76,10 @@ endif
 
 admin: $(LIB_CORE)
 ifeq ($(strip $(ADMIN_SRCS)),)
-		@echo "No admin tests"
+	@echo "No admin tests"
 else
-		$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../include/duke -I../third_party -I../core/include $(LIB_CORE) -o admin/run_tests
-		./admin/run_tests
+	$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../include/duke -I../third_party/nlohmann -I../core/include $(LIB_CORE) -o admin/run_tests
+	./admin/run_tests
 endif
 
 designer:
@@ -87,7 +87,7 @@ ifeq ($(strip $(DES_SRCS)),)
 	@echo "No designer tests"
 else
 	$(CXX) $(CXXFLAGS) $(DES_SRCS) ../apps/designer/DesignerApp.cpp $(PROD_LIB_SRCS) \
-	-I../apps/designer -I../include -I../include/duke -I../third_party -o designer/run_tests
+	-I../apps/designer -I../include -I../include/duke -I../third_party/nlohmann -I../core/include -o designer/run_tests
 	./designer/run_tests
 endif
 


### PR DESCRIPTION
## Summary
- specify nlohmann include directory instead of generic `third_party`
- drop unused third-party include flags
- add missing include and finance sources for test builds

## Testing
- `make -C tests core`
- `make -C tests finance`
- `make -C tests sales`
- `make -C tests admin`
- `make -C tests duke` *(fails: undefined reference to `duke::gui::ClearScreenWidget::render`)*
- `make -C tests designer` *(fails: undefined reference to `finance::FinanceRepo::load`)*

------
https://chatgpt.com/codex/tasks/task_e_68a5416e90b48327ad0dcd4dfc69223d