### PR TITLE
[docs] fix: correct third_party include path

### DIFF
--- a/docs/AGENTS.MD
+++ b/docs/AGENTS.MD
@@ -20,7 +20,7 @@
 - Verificar `CHECKLIST.md` e marcar entradas
 - Compilar com:
   ```sh
-  g++ -std=c++17 -Wall src/*.cpp -Iinclude -I../third_party -o app
+  g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app
   ```
 - Executar testes com: ./tests/run_tests
 - Commits no padrão Conventional Commits (`feat:`, `fix:`, `chore:`)


### PR DESCRIPTION
## Summary
- fix build instructions to use project third_party directory

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app` *(fails: undefined reference to finance symbols)*
- `make -C tests` *(fails: Package 'Qt6Core' not found)*

### 📝 Checklist deste PR
- [x] Revisão de código
- [ ] Testes adicionados e rodando
- [x] Documentação atualizada
- [ ] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a546e2fb388327b94ca4d1110537cb