### PR TITLE
Specify nlohmann include path for VSCode

### DIFF
--- a/scripts/start.bat
+++ b/scripts/start.bat
@@ -64,7 +64,7 @@ if not exist "%VSCODE_DIR%\c_cpp_properties.json" (
         echo             "name": "Linux",
         echo             "includePath": [
         echo                 "${workspaceFolder}/include",
-        echo                 "${workspaceFolder}/third_party"
+        echo                 "${workspaceFolder}/third_party/nlohmann"
         echo             ],
         echo             "defines": [],
         echo             "compilerPath": "/usr/bin/g++",


### PR DESCRIPTION
## Summary
- Narrow VS Code IntelliSense include path to `third_party/nlohmann` for clarity

## Testing
- `make -C core`
- `g++ -std=c++17 -Ithird_party/nlohmann /tmp/test_nlohmann.cpp -o /tmp/test_nlohmann`

------
https://chatgpt.com/codex/tasks/task_e_68a5987e79c883279253ea34c11cf22f