### PR TITLE
docs: add GUI build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ make cli
 ./app
 ```
 
+### Interface gráfica
+
+Para compilar e executar a interface gráfica:
+
+```sh
+cd src/duke
+make gui        # gera app_gui
+./app_gui       # executa
+```
+
+Certifique-se de que o Qt 6 esteja instalado e que `pkg-config` consiga encontrá-lo.
+
 ## Documentação
 
 A documentação detalhada está disponível na pasta [`docs/`](docs/):


### PR DESCRIPTION
## Summary
- document how to build and run the GUI app
- note that Qt 6 must be installed and visible via pkg-config

## Testing
- `make -C tests` *(fails: Interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a0ef480883278aaca279c0de2672