### PR TITLE
[docs] feat: especificar caminho de include nlohmann

### DIFF
--- a/docs/AGENTS.MD
+++ b/docs/AGENTS.MD
@@ -20,7 +20,7 @@
 - Verificar `CHECKLIST.md` e marcar entradas
 - Compilar com:
   ```sh
-  g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party -o app
+  g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party/nlohmann -o app
   ```
 - Executar testes com: ./tests/run_tests
 - Commits no padrão Conventional Commits (`feat:`, `fix:`, `chore:`)


### PR DESCRIPTION
## Summary
- document build command to include third_party/nlohmann header path.

## Testing
- `g++ -std=c++17 -Wall src/*.cpp -Iinclude -Ithird_party/nlohmann -o app` (fails: undefined references)
- `make -C tests` (fails: libduke.a Error 2)
- `./tests/run_tests` (fails: No such file or directory)

### Checklist
- [x] Revisão de código
- [ ] Testes adicionados e rodando
- [x] Documentação atualizada
- [ ] Build e lint
- [x] Commits padronizados

------
https://chatgpt.com/codex/tasks/task_e_68a5a1b100888327994198336843ba2e