### PR TITLE
Add build script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ as encontre antes de compilar.
 
 O projeto é dividido em módulos compilados separadamente.
 
+### Script de compilação
+
+Para compilar todos os módulos de uma só vez, utilize o script `build.sh`:
+
+```sh
+./build.sh
+```
+
+Ele executa `make` no núcleo `core`, compila a interface gráfica e a CLI do módulo `src/duke` e roda os testes.
+
 ### Núcleo `core`
 
 ```sh

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+(cd core && make) &&
+(cd src/duke && make gui && make cli) &&
+(cd tests && make)


### PR DESCRIPTION
## Summary
- add top-level `build.sh` to compile core, GUI, CLI and tests sequentially
- document new build script in README

## Testing
- `./build.sh` *(fails: Package 'Qt6Core', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a2fef1dc8327a78db9d878f3cd66