### PR TITLE
refactor: extract comparison module

### DIFF
--- a/include/duke/ApplicationCore.h
+++ b/include/duke/ApplicationCore.h
@@ -5,6 +5,7 @@
 #include "core/persist.h"
 #include "Material.h"
 #include "core.h"
+#include "comparison.h"
 #include "Customer.h"
 #include "Order.h"
 #include "finance/Repo.h"
@@ -28,18 +29,11 @@ public:
     std::vector<MaterialDTO> listarMateriais(const std::vector<MaterialDTO>& base) const;
 
     // Resultado da comparação de materiais com destaque para menor e maior preço por m².
-    struct MaterialComparado {
-        std::string nome;
-        double porm2 = 0.0;
-        bool menor = false;
-        bool maior = false;
-    };
-
     // Compara materiais selecionados pelos índices (base 0).
     // Exemplo:
     //   auto r = core.compararMateriais(mats, {0,1});
-    std::vector<MaterialComparado> compararMateriais(const std::vector<Material>& mats,
-                                                     const std::vector<int>& ids) const;
+    std::vector<comparison::MaterialComparado> compararMateriais(
+        const std::vector<Material>& mats, const std::vector<int>& ids) const;
 
     // ----- APIs do módulo de vendas -----
     // Carrega materiais, clientes e pedidos usando os arquivos JSON padrão.

--- a/include/duke/comparison.h
+++ b/include/duke/comparison.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "Material.h"
+
+namespace duke::comparison {
+
+struct MaterialComparado {
+    std::string nome;
+    double porm2 = 0.0;
+    bool menor = false;
+    bool maior = false;
+};
+
+struct Selecionados {
+    std::vector<Material> materiais;
+    std::vector<int> indices; // 0-based
+};
+
+Selecionados selecionarMateriais(const std::string& ids,
+                                 const std::vector<Material>& mats);
+std::vector<Material> selecionarMateriais(const std::vector<int>& ids,
+                                          const std::vector<Material>& mats);
+std::vector<MaterialComparado> compararMateriais(
+    const std::vector<Material>& matsSelecionados);
+
+} // namespace duke::comparison
+

--- a/src/duke/ApplicationCore.cpp
+++ b/src/duke/ApplicationCore.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <stdexcept>
 #include "core/Debug.h"
+#include "comparison.h"
 
 namespace duke {
 
@@ -36,33 +37,11 @@ std::vector<MaterialDTO> ApplicationCore::listarMateriais(const std::vector<Mate
     return base;
 }
 
-std::vector<ApplicationCore::MaterialComparado>
+std::vector<comparison::MaterialComparado>
 ApplicationCore::compararMateriais(const std::vector<Material>& mats,
                                    const std::vector<int>& ids) const {
-    if (ids.size() < 2) {
-        throw std::invalid_argument("Selecione ao menos dois materiais");
-    }
-    std::vector<Material> sel;
-    sel.reserve(ids.size());
-    for (int i : ids) {
-        if (i < 0 || static_cast<size_t>(i) >= mats.size()) {
-            throw std::out_of_range("Indice invalido");
-        }
-        sel.push_back(mats[static_cast<size_t>(i)]);
-    }
-    auto ext = core::extremosPorM2(sel);
-    std::vector<MaterialComparado> res;
-    res.reserve(ids.size());
-    for (int i : ids) {
-        const auto& m = mats[static_cast<size_t>(i)];
-        MaterialComparado mc;
-        mc.nome = m.getNome();
-        mc.porm2 = m.getPorm2();
-        if (m.getNome() == ext.menor.nome) mc.menor = true;
-        if (m.getNome() == ext.maior.nome) mc.maior = true;
-        res.push_back(mc);
-    }
-    return res;
+    auto sel = comparison::selecionarMateriais(ids, mats);
+    return comparison::compararMateriais(sel);
 }
 
 // ----- APIs do módulo de vendas -----

--- a/src/duke/cli/app.cpp
+++ b/src/duke/cli/app.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <algorithm> // std::clamp
 #include <sstream>
+#include <stdexcept>
 
 // Bibliotecas Personalizadas
 #include "cli/App.h"
@@ -26,6 +27,7 @@
 #include "cli/utils.h"
 #include "cli/commands.h"
 #include "finance/Serialize.h"
+#include "comparison.h"
 namespace duke {
 // ------------------------------------------------------------
 // Implementação do App
@@ -170,25 +172,20 @@ void App::compararMateriais() {
                   << "\n";
     }
     std::string linha = ui::readString("IDs separados por espaco: ");
-    std::istringstream iss(linha);
-    std::vector<int> ids; int id;
-    while (iss >> id) {
-        if (id >= 1 && id <= static_cast<int>(mats.size()))
-            ids.push_back(id - 1);
-    }
-    if (ids.size() < 2) {
-        std::cout << "Selecione ao menos dois materiais.\n";
-        return;
-    }
-    auto res = core.compararMateriais(mats, ids);
-    std::cout << "ID | Nome | porm2\n";
-    for (size_t i = 0; i < ids.size(); ++i) {
-        const auto& r = res[i];
-        std::string extra;
-        if (r.menor) extra = " <menor>";
-        if (r.maior) extra = " <maior>";
-        std::cout << ids[i] + 1 << " | " << r.nome << " | "
-                  << UN_MONE << r.porm2 << extra << "\n";
+    try {
+        auto sel = comparison::selecionarMateriais(linha, mats);
+        auto res = comparison::compararMateriais(sel.materiais);
+        std::cout << "ID | Nome | porm2\n";
+        for (size_t i = 0; i < res.size(); ++i) {
+            const auto& r = res[i];
+            std::string extra;
+            if (r.menor) extra = " <menor>";
+            if (r.maior) extra = " <maior>";
+            std::cout << sel.indices[i] + 1 << " | " << r.nome << " | "
+                      << UN_MONE << r.porm2 << extra << "\n";
+        }
+    } catch (const std::exception& e) {
+        std::cout << e.what() << "\n";
     }
 }
 

--- a/src/duke/comparison.cpp
+++ b/src/duke/comparison.cpp
@@ -1,0 +1,58 @@
+#include "comparison.h"
+#include <sstream>
+#include <stdexcept>
+#include "core.h"
+
+namespace duke::comparison {
+
+std::vector<Material> selecionarMateriais(const std::vector<int>& ids,
+                                          const std::vector<Material>& mats) {
+    if (ids.size() < 2) {
+        throw std::invalid_argument("Selecione ao menos dois materiais");
+    }
+    std::vector<Material> sel;
+    sel.reserve(ids.size());
+    for (int i : ids) {
+        if (i < 0 || static_cast<size_t>(i) >= mats.size()) {
+            throw std::out_of_range("Indice invalido");
+        }
+        sel.push_back(mats[static_cast<size_t>(i)]);
+    }
+    return sel;
+}
+
+Selecionados selecionarMateriais(const std::string& ids,
+                                 const std::vector<Material>& mats) {
+    std::istringstream iss(ids);
+    std::vector<int> vecIds;
+    int id = 0;
+    while (iss >> id) {
+        vecIds.push_back(id - 1);
+    }
+    Selecionados sel;
+    sel.materiais = selecionarMateriais(vecIds, mats);
+    sel.indices = std::move(vecIds);
+    return sel;
+}
+
+std::vector<MaterialComparado> compararMateriais(
+    const std::vector<Material>& matsSelecionados) {
+    if (matsSelecionados.size() < 2) {
+        throw std::invalid_argument("Selecione ao menos dois materiais");
+    }
+    auto ext = core::extremosPorM2(matsSelecionados);
+    std::vector<MaterialComparado> res;
+    res.reserve(matsSelecionados.size());
+    for (const auto& m : matsSelecionados) {
+        MaterialComparado mc;
+        mc.nome = m.getNome();
+        mc.porm2 = m.getPorm2();
+        if (m.getNome() == ext.menor.nome) mc.menor = true;
+        if (m.getNome() == ext.maior.nome) mc.maior = true;
+        res.push_back(mc);
+    }
+    return res;
+}
+
+} // namespace duke::comparison
+

--- a/tests/duke/comparison_test.cpp
+++ b/tests/duke/comparison_test.cpp
@@ -1,0 +1,41 @@
+#include "duke/comparison.h"
+#include <cassert>
+#include "core.h"
+
+void test_comparison() {
+    using namespace duke;
+    std::vector<MaterialDTO> base = {
+        {"Madeira", 100.0, 2.0, 3.0, "linear"},
+        {"Aco", 200.0, 1.0, 4.0, "linear"}
+    };
+    auto mats = core::reconstruirMateriais(base);
+
+    // caso valido
+    auto sel = comparison::selecionarMateriais("1 2", mats);
+    auto comps = comparison::compararMateriais(sel.materiais);
+    assert(comps.size() == 2);
+    bool menor = false, maior = false;
+    for (const auto& c : comps) {
+        if (c.menor) menor = true;
+        if (c.maior) maior = true;
+    }
+    assert(menor && maior);
+
+    // id invalido
+    bool threw = false;
+    try {
+        comparison::selecionarMateriais("1 3", mats);
+    } catch (const std::out_of_range&) {
+        threw = true;
+    }
+    assert(threw);
+
+    // ids insuficientes
+    threw = false;
+    try {
+        comparison::selecionarMateriais("1", mats);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    assert(threw);
+}

--- a/tests/duke/run_tests.cpp
+++ b/tests/duke/run_tests.cpp
@@ -25,6 +25,7 @@ void test_projeto_custo();
 void test_tempo();
 void test_menu();
 void test_application_core();
+void test_comparison();
 
 int main() {
     return run_tests({
@@ -51,6 +52,7 @@ int main() {
         test_projeto_custo,
         test_tempo,
         test_menu,
-        test_application_core
+        test_application_core,
+        test_comparison
     });
 }


### PR DESCRIPTION
## Summary
- add comparison module with material selection and comparison helpers
- refactor ApplicationCore and CLI to use new comparison utilities
- add unit tests for material comparison and invalid IDs

## Testing
- `cd src/duke && make libduke.a`
- `cd tests && make duke`

------
https://chatgpt.com/codex/tasks/task_e_68a5ca8eef1883279e889edd2c24f888