### PR TITLE
[core] feat: suporte a XML e API unificada

### DIFF
--- a/apps/production/ProductionApp.cpp
+++ b/apps/production/ProductionApp.cpp
@@ -8,7 +8,7 @@
 
 ProductionApp::ProductionApp() : core_(new duke::ApplicationCore()) {
     // Carrega dados básicos (stubbed na versão de testes)
-    core_->carregarJSON();
+    core_->carregar();
 
     // Define um modelo de produção com BOM e uma variante
     using namespace production;

--- a/apps/sales/SalesApp.cpp
+++ b/apps/sales/SalesApp.cpp
@@ -8,7 +8,7 @@
 
 SalesApp::SalesApp() : core_(new duke::ApplicationCore()) {
     // Load materials and customers on startup
-    core_->carregarJSON();
+    core_->carregar();
 }
 
 SalesApp::~SalesApp() {

--- a/core/Makefile
+++ b/core/Makefile
@@ -1,9 +1,10 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -Wall -fPIC
-INCLUDES = -Iinclude -I../include
+INCLUDES = -Iinclude -I../include -I../third_party/nlohmann
 QT_CFLAGS := $(shell pkg-config --cflags Qt6Core)
 QT_LIBS := $(shell pkg-config --libs Qt6Core)
 CXXFLAGS += $(QT_CFLAGS)
+XML_LIBS := $(shell pkg-config --libs tinyxml2 2>/dev/null || echo -ltinyxml2)
 
 SRC = $(wildcard src/*.cpp)
 OBJ = $(SRC:src/%.cpp=%.o)
@@ -14,7 +15,7 @@ libcore.a: $(OBJ)
 	ar rcs $@ $(OBJ)
 
 libcore.so: $(OBJ)
-	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(QT_LIBS) -o $@
+	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(QT_LIBS) $(XML_LIBS) -o $@
 
 %.o: src/%.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@

--- a/core/src/persist.cpp
+++ b/core/src/persist.cpp
@@ -1,0 +1,22 @@
+#include "core/persist.h"
+
+namespace Persist {
+
+bool save(const std::string& path, const std::vector<MaterialDTO>& v,
+          int schemaVersion, const std::string& baseDir) {
+    std::string ext = fs::path(path).extension().string();
+    if (ext == ".csv") return saveCSV(path, v, baseDir);
+    if (ext == ".xml") return saveXML(path, v, baseDir);
+    return saveJSON(path, v, schemaVersion, baseDir);
+}
+
+bool load(const std::string& path, std::vector<MaterialDTO>& out,
+          int* out_schema_version, const std::string& baseDir) {
+    std::string ext = fs::path(path).extension().string();
+    if (ext == ".csv") return loadCSV(path, out, baseDir);
+    if (ext == ".xml") return loadXML(path, out, baseDir);
+    return loadJSON(path, out, out_schema_version, baseDir);
+}
+
+} // namespace Persist
+

--- a/core/src/persist_csv.cpp
+++ b/core/src/persist_csv.cpp
@@ -1,0 +1,96 @@
+#include "core/persist.h"
+#include <sstream>
+
+namespace Persist {
+
+bool saveCSV(const std::string& path, const std::vector<MaterialDTO>& items,
+             const std::string& baseDir) {
+    for (const auto& m : items) {
+        if (!validar(m)) {
+            wr::p("PERSIST", "Material invalido: " + m.nome, "Red");
+            return false;
+        }
+    }
+
+    std::ostringstream oss;
+    oss << "nome;tipo;valor;largura;comprimento\n";
+
+    for (const auto& m : items) {
+        std::string safe = m.nome;
+        for (auto& ch : safe) if (ch == ';') ch = ',';
+        oss << safe << ';'
+            << m.tipo << ';'
+            << to_str_br(m.valor) << ';'
+            << to_str_br(m.largura) << ';'
+            << to_str_br(m.comprimento) << "\n";
+    }
+    return atomicWrite(fs::path(dataPath(path, baseDir)), oss.str());
+}
+
+bool loadCSV(const std::string& path, std::vector<MaterialDTO>& out,
+             const std::string& baseDir) {
+    const std::string p = dataPath(path, baseDir);
+    std::ifstream f(p);
+    if (!f) {
+        wr::p("PERSIST", p + " open fail", "Red");
+        return false;
+    }
+
+    out.clear();
+    std::string line;
+    if (!std::getline(f, line)) {
+        wr::p("PERSIST", p + " header read fail", "Red");
+        return false;
+    }
+
+    auto parseNum = [](const std::string& s, double& outVal) -> bool {
+        std::string tmp = detail::trim(s);
+        for (auto& ch : tmp) if (ch == ',') ch = '.';
+        try {
+            size_t idx = 0;
+            outVal = std::stod(tmp, &idx);
+            if (idx != tmp.size()) return false;
+            return true;
+        } catch (...) {
+            return false;
+        }
+    };
+
+    size_t lineNo = 1;
+    int invalidLines = 0;
+    while (std::getline(f, line)) {
+        ++lineNo;
+        if (line.empty()) continue;
+        std::vector<std::string> cols;
+        cols.reserve(5);
+        std::stringstream ss(line);
+        std::string item;
+        while (std::getline(ss, item, ';')) {
+            cols.push_back(item);
+        }
+        if (cols.size() != 5) {
+            wr::p("PERSIST", p + ":" + std::to_string(lineNo) + " coluna invalida", "Yellow");
+            ++invalidLines;
+            continue;
+        }
+
+        MaterialDTO m;
+        m.nome = detail::trim(cols[0]);
+        m.tipo = detail::trim(cols[1]);
+        if (m.tipo.empty()) m.tipo = "linear";
+        bool ok = parseNum(cols[2], m.valor) &&
+                  parseNum(cols[3], m.largura) &&
+                  parseNum(cols[4], m.comprimento);
+        if (!ok || !validar(m)) {
+            wr::p("PERSIST", p + ":" + std::to_string(lineNo) + " dados invalidos", "Yellow");
+            ++invalidLines;
+            continue;
+        }
+        out.push_back(std::move(m));
+    }
+    if (out.empty() && invalidLines > 0) return false;
+    return true;
+}
+
+} // namespace Persist
+

--- a/core/src/persist_json.cpp
+++ b/core/src/persist_json.cpp
@@ -1,0 +1,57 @@
+#include "core/persist.h"
+#include <nlohmann/json.hpp>
+
+using nlohmann::json;
+
+namespace Persist {
+
+bool saveJSON(const std::string& path, const std::vector<MaterialDTO>& v,
+              int schemaVersion, const std::string& baseDir) {
+    for (const auto& m : v) {
+        if (!validar(m)) {
+            wr::p("PERSIST", "Material invalido: " + m.nome, "Red");
+            return false;
+        }
+    }
+    json j;
+    j["schema_version"] = schemaVersion;
+    j["materiais"] = v;
+    return atomicWrite(fs::path(dataPath(path, baseDir)), j.dump(2));
+}
+
+bool loadJSON(const std::string& path, std::vector<MaterialDTO>& out,
+              int* out_schema_version, const std::string& baseDir) {
+    const std::string p = dataPath(path, baseDir);
+    std::ifstream f(p);
+    if (!f) {
+        wr::p("PERSIST", p + " open fail", "Red");
+        return false;
+    }
+    try {
+        json j; f >> j;
+        bool migrated = mater::upgradeIfNeeded(j);
+        int schemaVersion = j.value("schema_version", 1);
+        if (out_schema_version) *out_schema_version = schemaVersion;
+        if (j.contains("materiais") && j["materiais"].is_array()) {
+            out.clear();
+            for (const auto& item : j["materiais"]) {
+                out.push_back(item.get<MaterialDTO>());
+            }
+            if (migrated) {
+                atomicWrite(fs::path(p), j.dump(2));
+            }
+            return true;
+        }
+        wr::p("PERSIST", p + " missing 'materiais'", "Red");
+        return false;
+    } catch (const std::exception& e) {
+        wr::p("PERSIST", p + " parse error: " + e.what(), "Red");
+        return false;
+    } catch (...) {
+        wr::p("PERSIST", p + " unknown parse error", "Red");
+        return false;
+    }
+}
+
+} // namespace Persist
+

--- a/core/src/persist_xml.cpp
+++ b/core/src/persist_xml.cpp
@@ -1,0 +1,72 @@
+#include "core/persist.h"
+#include <tinyxml2.h>
+
+using namespace tinyxml2;
+
+namespace Persist {
+
+bool saveXML(const std::string& path, const std::vector<MaterialDTO>& items,
+             const std::string& baseDir) {
+    for (const auto& m : items) {
+        if (!validar(m)) {
+            wr::p("PERSIST", "Material invalido: " + m.nome, "Red");
+            return false;
+        }
+    }
+    XMLDocument doc;
+    auto* decl = doc.NewDeclaration();
+    doc.InsertFirstChild(decl);
+    auto* root = doc.NewElement("materiais");
+    root->SetAttribute("schema_version", 1);
+    for (const auto& m : items) {
+        auto* el = doc.NewElement("material");
+        el->SetAttribute("nome", m.nome.c_str());
+        el->SetAttribute("tipo", m.tipo.c_str());
+        el->SetAttribute("valor", m.valor);
+        el->SetAttribute("largura", m.largura);
+        el->SetAttribute("comprimento", m.comprimento);
+        root->InsertEndChild(el);
+    }
+    doc.InsertEndChild(root);
+    const std::string p = dataPath(path, baseDir);
+    if (doc.SaveFile(p.c_str()) != XML_SUCCESS) {
+        wr::p("PERSIST", p + " write fail", "Red");
+        return false;
+    }
+    return true;
+}
+
+bool loadXML(const std::string& path, std::vector<MaterialDTO>& out,
+             const std::string& baseDir) {
+    const std::string p = dataPath(path, baseDir);
+    XMLDocument doc;
+    if (doc.LoadFile(p.c_str()) != XML_SUCCESS) {
+        wr::p("PERSIST", p + " open fail", "Red");
+        return false;
+    }
+    auto* root = doc.FirstChildElement("materiais");
+    if (!root) {
+        wr::p("PERSIST", p + " missing 'materiais'", "Red");
+        return false;
+    }
+    out.clear();
+    int invalid = 0;
+    for (auto* el = root->FirstChildElement("material"); el; el = el->NextSiblingElement("material")) {
+        MaterialDTO m;
+        const char* nome = el->Attribute("nome");
+        const char* tipo = el->Attribute("tipo");
+        if (!nome) { ++invalid; continue; }
+        m.nome = nome;
+        m.tipo = tipo ? tipo : "linear";
+        el->QueryDoubleAttribute("valor", &m.valor);
+        el->QueryDoubleAttribute("largura", &m.largura);
+        el->QueryDoubleAttribute("comprimento", &m.comprimento);
+        if (!validar(m)) { ++invalid; continue; }
+        out.push_back(std::move(m));
+    }
+    if (out.empty() && invalid > 0) return false;
+    return !out.empty();
+}
+
+} // namespace Persist
+

--- a/docs/FORMATS.md
+++ b/docs/FORMATS.md
@@ -1,6 +1,8 @@
 # Formatos de Dados
 
-Exemplos unificados de estruturas para **Projetos**, **Relatórios** e **Tempos** utilizados no sistema.
+Exemplos unificados de estruturas para **Projetos**, **Relatórios** e **Tempos** utilizados no sistema. Os formatos
+suportados são JSON, CSV e XML. A API `Persist::save`/`load` escolhe o
+formato conforme a extensão do arquivo.
 
 ## Projetos
 Estrutura básica para armazenar projetos de corte.
@@ -20,6 +22,13 @@ Estrutura básica para armazenar projetos de corte.
 ```
 id,nome,material,quantidade
 p1,protótipo,m1,2
+```
+
+### Exemplo XML
+```xml
+<projeto id="p1" nome="protótipo">
+  <material id="m1" quantidade="2"/>
+</projeto>
 ```
 
 ## Relatórios

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -9,11 +9,12 @@ Responsável pela lógica de comparação e pelos cálculos de cortes e materiai
  - `include/duke/duke.hpp`
 
 ## Persistência de dados
-Centraliza leitura e escrita de informações em JSON ou CSV, além das
-configurações de execução. Antes de salvar, cada `MaterialDTO` é
-validado: o nome não pode ser vazio e nenhum valor numérico pode ser
+Centraliza leitura e escrita de informações em JSON, CSV ou XML,
+além das configurações de execução. Antes de salvar, cada `MaterialDTO`
+é validado: o nome não pode ser vazio e nenhum valor numérico pode ser
 negativo. Caso algum item seja inválido, a operação é abortada e um
-aviso em vermelho é emitido.
+aviso em vermelho é emitido. A API `Persist::save`/`load` seleciona o
+formato de acordo com a extensão do arquivo.
  Principais arquivos:
  - `include/duke/persist.hpp`
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,7 +6,7 @@ O DUKE evoluirá em etapas para oferecer mais flexibilidade e confiabilidade.
 
 - [ ] [P1] Separar a lógica do app em módulos (`src/duke/ApplicationCore.cpp`, `include/duke/duke.hpp`, `src/duke/main.cpp`).
 - [ ] [P1] Extrair a lógica de comparação e seleção de materiais em funções reutilizáveis.
-- [ ] [P1] Centralizar leitura/escrita em formatos adicionais (ex.: XML).
+- [x] [P1] Centralizar leitura/escrita em formatos adicionais (ex.: XML).
 - [ ] [P2] Melhorar mensagens de erro para entradas inválidas.
 - [ ] [P1] Criar casos de teste unitários para validar comparações e rotinas de persistência.
 - [ ] [P2] Integrar com execução contínua (CI) para evitar regressões.

--- a/include/duke/ApplicationCore.h
+++ b/include/duke/ApplicationCore.h
@@ -15,13 +15,14 @@ namespace duke {
 // Camada central de operacoes do aplicativo sem interacao direta com o usuario.
 class ApplicationCore {
 public:
-    // Carrega materiais a partir de um arquivo JSON. Retorna false se menos de dois materiais forem carregados.
+    // Carrega materiais a partir de um arquivo de dados (JSON, CSV ou XML).
+    // Retorna false se menos de dois materiais forem carregados.
     // Exemplo:
     //   ApplicationCore core;
     //   std::vector<MaterialDTO> base;
     //   std::vector<Material> mats;
-    //   bool ok = core.carregarJSON(base, mats);
-    bool carregarJSON(std::vector<MaterialDTO>& base, std::vector<Material>& mats);
+    //   bool ok = core.carregar(base, mats);
+    bool carregar(std::vector<MaterialDTO>& base, std::vector<Material>& mats);
 
     // Lista materiais disponíveis. O retorno é uma cópia dos dados para exibição.
     // Exemplo:
@@ -36,11 +37,11 @@ public:
         const std::vector<Material>& mats, const std::vector<int>& ids) const;
 
     // ----- APIs do módulo de vendas -----
-    // Carrega materiais, clientes e pedidos usando os arquivos JSON padrão.
+    // Carrega materiais, clientes e pedidos usando os arquivos padrão.
     // Exemplo:
     //   ApplicationCore core;
-    //   core.carregarJSON();
-    bool carregarJSON();
+    //   core.carregar();
+    bool carregar();
 
     // Cria e persiste um novo pedido.
     // Exemplo:

--- a/include/duke/cli/App.h
+++ b/include/duke/cli/App.h
@@ -17,7 +17,7 @@ private:
     ApplicationCore core; // camada de regras de negócio
 
     void importarCSV();
-    bool carregarJSON();
+    bool carregar();
     void menuMateriais();
     void escolherPreco();
     void solicitarCortes();

--- a/src/duke/ApplicationCore.cpp
+++ b/src/duke/ApplicationCore.cpp
@@ -6,15 +6,15 @@
 
 namespace duke {
 
-bool ApplicationCore::carregarJSON(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
+bool ApplicationCore::carregar(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
     int schemaVersion = 0;
-    if (!::Persist::loadJSON("materiais.json", base, &schemaVersion) || base.empty()) {
+    if (!::Persist::load("materiais.json", base, &schemaVersion) || base.empty()) {
         wr::p("DATA", "Base nao encontrada. Criando materiais padrao...", "Yellow");
         base = {
             {"Pinus 20cm", 17.00, 0.20, 3.00, "linear"},
             {"MDF 15mm", 180.00, 1.85, 2.75, "linear"}
         };
-        if (::Persist::saveJSON("materiais.json", base, 1)) {
+        if (::Persist::save("materiais.json", base, 1)) {
             wr::p("DATA", "materiais.json criado.", "Green");
         } else {
             wr::p("DATA", "Falha ao criar materiais.json", "Red");
@@ -45,16 +45,16 @@ ApplicationCore::compararMateriais(const std::vector<Material>& mats,
 }
 
 // ----- APIs do módulo de vendas -----
-bool ApplicationCore::carregarJSON() {
+bool ApplicationCore::carregar() {
     // Carrega materiais reutilizando a função existente
     int schemaVersion = 0;
-    if (!::Persist::loadJSON("materiais.json", base_, &schemaVersion) || base_.empty()) {
+    if (!::Persist::load("materiais.json", base_, &schemaVersion) || base_.empty()) {
         wr::p("DATA", "Base nao encontrada. Criando materiais padrao...", "Yellow");
         base_ = {
             {"Pinus 20cm", 17.00, 0.20, 3.00, "linear"},
             {"MDF 15mm", 180.00, 1.85, 2.75, "linear"}
         };
-        ::Persist::saveJSON("materiais.json", base_, 1);
+        ::Persist::save("materiais.json", base_, 1);
     }
     mats_ = core::reconstruirMateriais(base_);
 

--- a/src/duke/cli/app.cpp
+++ b/src/duke/cli/app.cpp
@@ -54,8 +54,8 @@ void App::importarCSV() {
     }
 }
 
-bool App::carregarJSON() {
-    return core.carregarJSON(base, mats);
+bool App::carregar() {
+    return core.carregar(base, mats);
 }
 
 void App::menuMateriais() {
@@ -377,7 +377,7 @@ void App::iniciar(bool autoMode) {
     std::cout << std::fixed << std::setprecision(dec);
 
     importarCSV();
-    if (!carregarJSON()) return;
+    if (!carregar()) return;
     q = core::extremosPorM2(mats);
 
     ui::MenuState state = ui::MenuState::Principal;

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,6 +6,7 @@ CALC_DIR = ../src/duke
 
 LIB_CORE = $(CORE_DIR)/libcore.a
 LIB_CALC = $(CALC_DIR)/libduke.a
+XML_LIBS := $(shell pkg-config --libs tinyxml2 2>/dev/null || echo -ltinyxml2)
 
 CALC_SRCS := $(wildcard duke/*.cpp)
 CORE_SRCS := $(wildcard core/*.cpp)
@@ -26,9 +27,9 @@ all: duke core finance admin designer production sales
 
 duke: $(LIB_CALC) $(LIB_CORE)
 ifeq ($(strip $(CALC_SRCS)),)
-        @echo "No DUKE tests"
+	@echo "No DUKE tests"
 else
-	$(CXX) $(CXXFLAGS) -include duke/namespace.h $(CALC_SRCS) -I../include -I../include/duke -I../third_party/nlohmann -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) -o duke/run_tests
+	$(CXX) $(CXXFLAGS) -include duke/namespace.h $(CALC_SRCS) -I../include -I../include/duke -I../third_party/nlohmann -I$(CORE_DIR)/include $(LIB_CALC) $(LIB_CORE) $(XML_LIBS) -o duke/run_tests
 	./duke/run_tests
 endif
 
@@ -36,7 +37,7 @@ core: $(LIB_CORE)
 ifeq ($(strip $(CORE_SRCS)),)
 	@echo "No core tests"
 else
-	$(CXX) $(CXXFLAGS) $(CORE_SRCS) $(FIN_LIB_SRCS) -I$(CORE_DIR)/include -I../include -I../third_party/nlohmann $(LIB_CORE) -o core/run_tests
+	$(CXX) $(CXXFLAGS) $(CORE_SRCS) $(FIN_LIB_SRCS) -I$(CORE_DIR)/include -I../include -I../third_party/nlohmann $(LIB_CORE) $(XML_LIBS) -o core/run_tests
 	./core/run_tests
 endif
 
@@ -44,7 +45,7 @@ finance:
 ifeq ($(strip $(FIN_SRCS)),)
 	@echo "No finance tests"
 else
-	$(CXX) $(CXXFLAGS) $(FIN_SRCS) $(FIN_LIB_SRCS) -I../include -I../include/duke -I../third_party/nlohmann -I../core/include -o finance/run_tests
+	$(CXX) $(CXXFLAGS) $(FIN_SRCS) $(FIN_LIB_SRCS) -I../include -I../include/duke -I../third_party/nlohmann -I../core/include $(LIB_CORE) $(XML_LIBS) -o finance/run_tests
 	./finance/run_tests
 endif
   
@@ -56,7 +57,7 @@ else
 	@mkdir -p production
 	$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) \
 	-Iproduction -I.. -I../include -I../include/duke -I../core/include \
-	$(LIB_CORE) \
+	$(LIB_CORE) $(XML_LIBS) \
 	-o production/run_tests
 	./production/run_tests
 endif
@@ -68,7 +69,7 @@ else
 	@mkdir -p sales
 	$(CXX) $(CXXFLAGS) $(SALES_SRCS) \
 	-I../include -I../include/duke -I../third_party/nlohmann -I$(CORE_DIR)/include \
-	$(LIB_CALC) $(LIB_CORE) \
+	$(LIB_CALC) $(LIB_CORE) $(XML_LIBS) \
 	-o sales/run_tests
 	./sales/run_tests
 endif
@@ -78,7 +79,7 @@ admin: $(LIB_CORE)
 ifeq ($(strip $(ADMIN_SRCS)),)
 	@echo "No admin tests"
 else
-	$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../include/duke -I../third_party/nlohmann -I../core/include $(LIB_CORE) -o admin/run_tests
+	$(CXX) $(CXXFLAGS) $(ADMIN_SRCS) $(ADMIN_APP_SRCS) $(FIN_LIB_SRCS) -I.. -I../include -I../include/duke -I../third_party/nlohmann -I../core/include $(LIB_CORE) $(XML_LIBS) -o admin/run_tests
 	./admin/run_tests
 endif
 
@@ -87,7 +88,7 @@ ifeq ($(strip $(DES_SRCS)),)
 	@echo "No designer tests"
 else
 	$(CXX) $(CXXFLAGS) $(DES_SRCS) ../apps/designer/DesignerApp.cpp $(PROD_LIB_SRCS) \
-	-I../apps/designer -I../include -I../include/duke -I../third_party/nlohmann -I../core/include -o designer/run_tests
+	-I../apps/designer -I../include -I../include/duke -I../third_party/nlohmann -I../core/include $(LIB_CORE) $(XML_LIBS) -o designer/run_tests
 	./designer/run_tests
 endif
 

--- a/tests/duke/application_core_test.cpp
+++ b/tests/duke/application_core_test.cpp
@@ -12,12 +12,12 @@ void test_application_core() {
         {"Madeira", 100.0, 2.0, 3.0, "linear"},
         {"Aco", 200.0, 1.0, 4.0, "linear"}
     };
-    Persist::saveJSON("materiais.json", itens);
+    Persist::save("materiais.json", itens);
 
     ApplicationCore core;
     std::vector<MaterialDTO> base;
     std::vector<Material> mats;
-    assert(core.carregarJSON(base, mats));
+    assert(core.carregar(base, mats));
     auto lista = core.listarMateriais(base);
     assert(lista.size() == 2);
     auto comps = core.compararMateriais(mats, {0, 1});

--- a/tests/duke/persist_io_test.cpp
+++ b/tests/duke/persist_io_test.cpp
@@ -25,7 +25,15 @@ void test_persist_io() {
     assert(carregado[0].valor == 10.0);
     assert(carregado[0].tipo == "linear");
 
+    // Salva e carrega XML usando API unificada
+    assert(Persist::save("teste_io.xml", itens));
+    carregado.clear();
+    assert(Persist::load("teste_io.xml", carregado));
+    assert(carregado.size() == 1);
+    assert(carregado[0].nome == "Madeira");
+
     // Limpa arquivos de teste
     std::filesystem::remove("data/teste_io.json");
     std::filesystem::remove("data/teste_io.csv");
+    std::filesystem::remove("data/teste_io.xml");
 }

--- a/tests/production/ApplicationCore.h
+++ b/tests/production/ApplicationCore.h
@@ -2,6 +2,6 @@
 namespace duke {
 class ApplicationCore {
 public:
-    void carregarJSON() {}
+    void carregar() {}
 };
 }

--- a/tests/sales/sales_core_test.cpp
+++ b/tests/sales/sales_core_test.cpp
@@ -10,12 +10,12 @@ void test_criar_pedido() {
     std::filesystem::remove_all("tmp_sales");
     Persist::Config cfg; cfg.baseDir = "tmp_sales"; Persist::setConfig(cfg);
     std::vector<MaterialDTO> mats{{"Prod", 10.0, 1.0, 1.0, "linear"}};
-    Persist::saveJSON("materiais.json", mats);
+    Persist::save("materiais.json", mats);
     std::vector<Customer> clientes{Customer{"Ana"}};
     Persist::saveJSONVec("clientes.json", clientes, "clientes");
 
     ApplicationCore core;
-    core.carregarJSON();
+    core.carregar();
     assert(core.criarPedido("Ana", "Prod", 1));
     auto pedidos = core.listarPedidos();
     assert(pedidos.size() == 1);
@@ -30,9 +30,9 @@ void test_listar_clientes() {
     Persist::Config cfg; cfg.baseDir = "tmp_sales_cli"; Persist::setConfig(cfg);
     std::vector<Customer> clientes{Customer{"Bia"}, Customer{"Carlos"}};
     Persist::saveJSONVec("clientes.json", clientes, "clientes");
-    Persist::saveJSON("materiais.json", std::vector<MaterialDTO>{{"X",1,1,1,"linear"}});
+    Persist::save("materiais.json", std::vector<MaterialDTO>{{"X",1,1,1,"linear"}});
 
-    ApplicationCore core; core.carregarJSON();
+    ApplicationCore core; core.carregar();
     auto lista = core.listarClientes();
     assert(lista.size() == 2);
     assert(lista[0].nome == "Bia");
@@ -45,9 +45,9 @@ void test_consulta_estoque() {
     std::filesystem::remove_all("tmp_sales_inv");
     Persist::Config cfg; cfg.baseDir = "tmp_sales_inv"; Persist::setConfig(cfg);
     std::vector<MaterialDTO> mats{{"Estoque", 5.0, 1.0, 1.0, "linear"}};
-    Persist::saveJSON("materiais.json", mats);
+    Persist::save("materiais.json", mats);
 
-    ApplicationCore core; core.carregarJSON();
+    ApplicationCore core; core.carregar();
     auto estoque = core.listarEstoque();
     assert(estoque.size() == 1);
     assert(estoque[0].nome == "Estoque");


### PR DESCRIPTION
## Summary
- extrai leitura/escrita de formatos para módulos dedicados
- adiciona suporte a XML e API Persist::save/load
- atualiza ApplicationCore e documentação para nova API

## Testing
- `make -C core`
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_e_68a5cff0e78483278ea34b3763bf107f