### PR TITLE
Introduce centralized error handling

### DIFF
--- a/core/include/core/persist.h
+++ b/core/include/core/persist.h
@@ -13,6 +13,7 @@
 #include <system_error>
 #include <cstdlib>
 #include "core/Debug.h"
+#include "duke/error.h"
 
 namespace fs = std::filesystem;
 
@@ -92,15 +93,16 @@ inline void setConfig(const Config& cfg) { config() = cfg; }
 // Valida MaterialDTO: nome nao vazio e valores >=0
 // Exemplo:
 //   MaterialDTO m{"Madeira", 10, 2, 3};
-//   bool ok = Persist::validar(m); // true
+//   auto err = Persist::validar(m); // err.code == ErrorCode::Ok
 // ------------------------------------------------
-inline bool validar(const MaterialDTO& m) {
-    if (m.nome.empty()) return false;
-    if (m.valor < 0) return false;
-    if (m.largura < 0) return false;
-    if (m.comprimento < 0) return false;
-    if (m.tipo != "unitario" && m.tipo != "linear" && m.tipo != "cubico") return false;
-    return true;
+inline duke::ErrorDetail validar(const MaterialDTO& m) {
+    if (m.nome.empty()) return {duke::ErrorCode::EmptyField, "nome"};
+    if (m.valor < 0) return {duke::ErrorCode::NegativeValue, "valor"};
+    if (m.largura < 0) return {duke::ErrorCode::NegativeValue, "largura"};
+    if (m.comprimento < 0) return {duke::ErrorCode::NegativeValue, "comprimento"};
+    if (m.tipo != "unitario" && m.tipo != "linear" && m.tipo != "cubico")
+        return {duke::ErrorCode::InvalidType, "tipo"};
+    return {duke::ErrorCode::Ok, ""};
 }
 
 // ----------------------------------------------

--- a/core/src/persist_csv.cpp
+++ b/core/src/persist_csv.cpp
@@ -6,8 +6,9 @@ namespace Persist {
 bool saveCSV(const std::string& path, const std::vector<MaterialDTO>& items,
              const std::string& baseDir) {
     for (const auto& m : items) {
-        if (!validar(m)) {
-            wr::p("PERSIST", "Material invalido: " + m.nome, "Red");
+        auto err = validar(m);
+        if (err.code != duke::ErrorCode::Ok) {
+            wr::p("PERSIST", duke::errorMessage(err.code, err.field) + ": " + m.nome, "Red");
             return false;
         }
     }
@@ -81,8 +82,9 @@ bool loadCSV(const std::string& path, std::vector<MaterialDTO>& out,
         bool ok = parseNum(cols[2], m.valor) &&
                   parseNum(cols[3], m.largura) &&
                   parseNum(cols[4], m.comprimento);
-        if (!ok || !validar(m)) {
-            wr::p("PERSIST", p + ":" + std::to_string(lineNo) + " dados invalidos", "Yellow");
+        auto err = validar(m);
+        if (!ok || err.code != duke::ErrorCode::Ok) {
+            wr::p("PERSIST", p + ":" + std::to_string(lineNo) + " " + duke::errorMessage(err.code, err.field), "Yellow");
             ++invalidLines;
             continue;
         }

--- a/core/src/persist_json.cpp
+++ b/core/src/persist_json.cpp
@@ -8,8 +8,9 @@ namespace Persist {
 bool saveJSON(const std::string& path, const std::vector<MaterialDTO>& v,
               int schemaVersion, const std::string& baseDir) {
     for (const auto& m : v) {
-        if (!validar(m)) {
-            wr::p("PERSIST", "Material invalido: " + m.nome, "Red");
+        auto err = validar(m);
+        if (err.code != duke::ErrorCode::Ok) {
+            wr::p("PERSIST", duke::errorMessage(err.code, err.field) + ": " + m.nome, "Red");
             return false;
         }
     }

--- a/core/src/persist_xml.cpp
+++ b/core/src/persist_xml.cpp
@@ -8,8 +8,9 @@ namespace Persist {
 bool saveXML(const std::string& path, const std::vector<MaterialDTO>& items,
              const std::string& baseDir) {
     for (const auto& m : items) {
-        if (!validar(m)) {
-            wr::p("PERSIST", "Material invalido: " + m.nome, "Red");
+        auto err = validar(m);
+        if (err.code != duke::ErrorCode::Ok) {
+            wr::p("PERSIST", duke::errorMessage(err.code, err.field) + ": " + m.nome, "Red");
             return false;
         }
     }
@@ -61,7 +62,8 @@ bool loadXML(const std::string& path, std::vector<MaterialDTO>& out,
         el->QueryDoubleAttribute("valor", &m.valor);
         el->QueryDoubleAttribute("largura", &m.largura);
         el->QueryDoubleAttribute("comprimento", &m.comprimento);
-        if (!validar(m)) { ++invalid; continue; }
+        auto err = validar(m);
+        if (err.code != duke::ErrorCode::Ok) { ++invalid; continue; }
         out.push_back(std::move(m));
     }
     if (out.empty() && invalid > 0) return false;

--- a/include/duke/cli/args.h
+++ b/include/duke/cli/args.h
@@ -7,6 +7,7 @@
 #include <vector>
 #include <optional>
 #include "finance/Tipos.h"
+#include "duke/error.h"
 namespace duke {
 
 // Comandos reconhecidos pela aplicação (ainda não implementados)
@@ -42,14 +43,13 @@ struct CliOptions {
     std::optional<bool> finEntrada; // entrada ou saída
     std::string finDtIni;        // filtro data inicial
     std::string finDtFim;        // filtro data final
-    std::vector<std::string> naoMapeados; // argumentos não reconhecidos
-    bool ok = true;             // falso se houve tokens não mapeados
+    std::vector<duke::ErrorDetail> errors; // lista de erros encontrados
 };
 
 // Processa argc/argv e devolve opções reconhecidas
 // Exemplo de uso:
 //   CliOptions opt = parseArgs(argc, argv);
-//   if (!opt.ok) return 1; // argumentos inválidos
+//   if (!opt.errors.empty()) return 1; // argumentos inválidos
 CliOptions parseArgs(int argc, char* argv[]);
 
 } // namespace duke

--- a/include/duke/error.h
+++ b/include/duke/error.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <string>
+#include <vector>
+
+namespace duke {
+
+enum class ErrorCode {
+    Ok = 0,
+    InvalidNumber,
+    UnknownArgument,
+    InvalidId,
+    MissingField,
+    EmptyField,
+    NegativeValue,
+    InvalidType
+};
+
+inline std::string errorCause(ErrorCode c) {
+    switch (c) {
+        case ErrorCode::InvalidNumber: return "valor invalido";
+        case ErrorCode::UnknownArgument: return "argumento desconhecido";
+        case ErrorCode::InvalidId: return "ID invalido";
+        case ErrorCode::MissingField: return "campo obrigatorio";
+        case ErrorCode::EmptyField: return "campo vazio";
+        case ErrorCode::NegativeValue: return "valor negativo";
+        case ErrorCode::InvalidType: return "tipo invalido";
+        default: return "";
+    }
+}
+
+inline std::string errorMessage(ErrorCode c, const std::string& field = {}) {
+    std::string cause = errorCause(c);
+    if (field.empty() || cause.empty()) return cause;
+    return field + ": " + cause;
+}
+
+struct ErrorDetail {
+    ErrorCode code = ErrorCode::Ok;
+    std::string field;
+};
+
+} // namespace duke
+

--- a/src/duke/cli/app.cpp
+++ b/src/duke/cli/app.cpp
@@ -124,8 +124,9 @@ void App::criarMaterial() {
             m.comprimento = ui::readDouble("Comprimento padrao (m): ");
             break;
     }
-    if (!::Persist::validar(m)) {
-        wr::p("APP", "Material invalido, nada salvo.", "Red");
+    auto err = ::Persist::validar(m);
+    if (err.code != ErrorCode::Ok) {
+        wr::p("APP", errorMessage(err.code, err.field), "Red");
         return;
     }
     base.push_back(m);

--- a/src/duke/cli/processor.cpp
+++ b/src/duke/cli/processor.cpp
@@ -5,6 +5,7 @@
 #include "core/Debug.h"
 #include "ApplicationCore.h"
 #include "finance/Serialize.h"
+#include "duke/error.h"
 
 namespace duke {
 
@@ -33,8 +34,8 @@ int processarComando(const CliOptions& opt) {
         return 0;
     }
 
-    if (!opt.ok) {
-        return 1;
+    if (!opt.errors.empty()) {
+        return static_cast<int>(opt.errors.front().code);
     }
 
     if (opt.finCmd != FinCmd::None) {
@@ -42,19 +43,19 @@ int processarComando(const CliOptions& opt) {
         core.carregarFinanceiro();
         if (opt.finCmd == FinCmd::Add) {
             if (!opt.finTipo) {
-                wr::p("FIN", "--tipo obrigatorio", "Red");
-                return 1;
+                wr::p("FIN", errorMessage(ErrorCode::MissingField, "--tipo"), "Red");
+                return static_cast<int>(ErrorCode::MissingField);
             }
             if (!opt.finValor || *opt.finValor <= 0.0) {
-                wr::p("FIN", "--valor deve ser >0", "Red");
-                return 1;
+                wr::p("FIN", errorMessage(ErrorCode::InvalidNumber, "--valor"), "Red");
+                return static_cast<int>(ErrorCode::InvalidNumber);
             }
             if (opt.finData.empty()) {
-                wr::p("FIN", "--data obrigatoria (AAAA-MM-DD)", "Red");
-                return 1;
+                wr::p("FIN", errorMessage(ErrorCode::MissingField, "--data"), "Red");
+                return static_cast<int>(ErrorCode::MissingField);
             }
             if (opt.finSubtipo.empty()) {
-                wr::p("FIN", "Subtipo recomendado. Veja --help para sugestoes", "Yellow");
+                wr::p("FIN", errorMessage(ErrorCode::MissingField, "--subtipo"), "Yellow");
             }
             finance::Lancamento l;
             l.id = core.proximoIdLancamento();

--- a/src/duke/main.cpp
+++ b/src/duke/main.cpp
@@ -21,7 +21,9 @@ using namespace duke;
 int main(int argc, char* argv[]) {
     // Interpreta opções da linha de comando
     CliOptions opt = parseArgs(argc, argv);
-
+    if (!opt.errors.empty()) {
+        return static_cast<int>(opt.errors.front().code);
+    }
     // Processa comandos através da interface pública
     return processarComando(opt);
 }

--- a/tests/core/persist_error_test.cpp
+++ b/tests/core/persist_error_test.cpp
@@ -1,0 +1,10 @@
+#include "core/persist.h"
+#include "duke/error.h"
+#include <cassert>
+
+void test_persist_validar_message() {
+    MaterialDTO inv{"A", 1.0, 0.0, 0.0, "foo"};
+    duke::ErrorDetail err = Persist::validar(inv);
+    assert(err.code == duke::ErrorCode::InvalidType);
+    assert(duke::errorMessage(err.code, err.field) == "tipo: tipo invalido");
+}

--- a/tests/core/run_tests.cpp
+++ b/tests/core/run_tests.cpp
@@ -5,6 +5,7 @@ void test_restore_backup();
 void test_monthly_summary();
 void test_generate_report();
 void test_overdue_alert();
+void test_persist_validar_message();
 
 int main() {
     return run_tests({
@@ -12,6 +13,7 @@ int main() {
         test_restore_backup,
         test_monthly_summary,
         test_generate_report,
-        test_overdue_alert
+        test_overdue_alert,
+        test_persist_validar_message
     });
 }

--- a/tests/duke/cli_test.cpp
+++ b/tests/duke/cli_test.cpp
@@ -1,4 +1,5 @@
 #include "duke/cli/args.h"
+#include "duke/error.h"
 #include <cassert>
 
 // Testa o parsing de argumentos basicos
@@ -51,5 +52,7 @@ void test_cli() {
     const char* a10[] = {"app", "fin", "add", "--valor", "abc"};
     CliOptions o10 = parseArgs(5, const_cast<char**>(a10));
     assert(!o10.finValor.has_value());
-    assert(!o10.ok);
+    assert(o10.errors.size() == 1);
+    assert(o10.errors[0].code == ErrorCode::InvalidNumber);
+    assert(errorMessage(o10.errors[0].code, o10.errors[0].field).find("valor") != std::string::npos);
 }

--- a/tests/duke/material_validacao_tipo_test.cpp
+++ b/tests/duke/material_validacao_tipo_test.cpp
@@ -7,11 +7,11 @@ void testValidarMaterialPorTipo() {
     MaterialDTO unit{"U", 1.0, 0.0, 0.0, "unitario"};
     MaterialDTO lin{"L", 1.0, 0.0, 0.0, "linear"};
     MaterialDTO cub{"C", 1.0, 0.0, 0.0, "cubico"};
-    assert(Persist::validar(unit));
-    assert(Persist::validar(lin));
-    assert(Persist::validar(cub));
+    assert(Persist::validar(unit).code == ErrorCode::Ok);
+    assert(Persist::validar(lin).code == ErrorCode::Ok);
+    assert(Persist::validar(cub).code == ErrorCode::Ok);
 
     // Tipo inválido
     MaterialDTO inv{"X", 1.0, 0.0, 0.0, "foo"};
-    assert(!Persist::validar(inv));
+    assert(Persist::validar(inv).code == ErrorCode::InvalidType);
 }


### PR DESCRIPTION
## Summary
- add duke::ErrorCode with common error messages
- return error codes from CLI and persistence validations
- test standardized messages for CLI parsing and persistence

## Testing
- `make duke core`

------
https://chatgpt.com/codex/tasks/task_e_68a5d78f098483278fd6d4ac6746e8b8