### PR TITLE
Add persist load/save tests and enhance application core validation

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,7 +9,7 @@ LIB_CALC = $(CALC_DIR)/libduke.a
 XML_LIBS := $(shell pkg-config --libs tinyxml2 2>/dev/null || echo -ltinyxml2)
 
 CALC_SRCS := $(wildcard duke/*.cpp)
-CORE_SRCS := $(wildcard core/*.cpp)
+CORE_SRCS := $(wildcard core/*_test.cpp) core/run_tests.cpp
 FIN_SRCS := $(wildcard finance/*.cpp)
 FIN_LIB_SRCS := $(wildcard ../src/finance/*.cpp)
 

--- a/tests/core/persist_load_save_test.cpp
+++ b/tests/core/persist_load_save_test.cpp
@@ -1,0 +1,35 @@
+#include "core/persist.h"
+#include <cassert>
+#include <filesystem>
+
+void test_persist_load_save() {
+    std::filesystem::remove_all("tmp_persist");
+    Persist::Config cfg; cfg.baseDir = "tmp_persist";
+    Persist::setConfig(cfg);
+
+    std::vector<MaterialDTO> itens = {
+        {"Madeira", 100.0, 2.0, 3.0, "linear"},
+        {"Aco", 200.0, 1.0, 4.0, "linear"}
+    };
+
+    assert(Persist::saveJSON("materiais.json", itens));
+    std::vector<MaterialDTO> out;
+    assert(Persist::loadJSON("materiais.json", out));
+    assert(out.size() == itens.size());
+    assert(out[0].nome == itens[0].nome);
+
+    std::vector<MaterialDTO> dummy;
+    assert(!Persist::loadJSON("inexistente.json", dummy));
+    std::vector<MaterialDTO> invalido{{"", -1.0, 1.0, 1.0, "linear"}};
+    assert(!Persist::saveJSON("invalido.json", invalido));
+
+    assert(Persist::saveXML("materiais.xml", itens));
+    out.clear();
+    assert(Persist::loadXML("materiais.xml", out));
+    assert(out.size() == itens.size());
+
+    out.clear();
+    assert(!Persist::loadXML("inexistente.xml", out));
+    assert(!Persist::saveXML("invalido.xml", invalido));
+}
+

--- a/tests/core/run_tests.cpp
+++ b/tests/core/run_tests.cpp
@@ -6,6 +6,7 @@ void test_monthly_summary();
 void test_generate_report();
 void test_overdue_alert();
 void test_persist_validar_message();
+void test_persist_load_save();
 
 int main() {
     return run_tests({
@@ -14,6 +15,7 @@ int main() {
         test_monthly_summary,
         test_generate_report,
         test_overdue_alert,
-        test_persist_validar_message
+        test_persist_validar_message,
+        test_persist_load_save
     });
 }

--- a/tests/duke/application_core_test.cpp
+++ b/tests/duke/application_core_test.cpp
@@ -1,6 +1,7 @@
 #include "duke/ApplicationCore.h"
 #include <cassert>
 #include <filesystem>
+#include <stdexcept>
 #include "core/persist.h"
 
 void test_application_core() {
@@ -28,4 +29,20 @@ void test_application_core() {
         if (c.maior) maior = true;
     }
     assert(menor && maior);
+
+    bool threw = false;
+    try {
+        core.compararMateriais(mats, {0, 2});
+    } catch (const std::out_of_range&) {
+        threw = true;
+    }
+    assert(threw);
+
+    std::vector<MaterialDTO> single = {
+        {"Madeira", 100.0, 2.0, 3.0, "linear"}
+    };
+    Persist::save("materiais.json", single);
+    base.clear();
+    mats.clear();
+    assert(!core.carregar(base, mats));
 }


### PR DESCRIPTION
## Summary
- extend ApplicationCore tests to cover invalid material indices and insufficient material lists
- add Persist load/save regression tests for JSON and XML, including failure scenarios
- include new core test in build system

## Testing
- `cd tests && make core duke`

------
https://chatgpt.com/codex/tasks/task_e_68a5dcd8626c8327b0982c9f551a3add