### PR TITLE
ci: expand workflow with caching and matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,64 @@ name: CI
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
 
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: |
+            core
+            src/duke
+          key: ${{ runner.os }}-build-${{ hashFiles('core/**','src/duke/**','tests/**') }}
+
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y g++ make nlohmann-json3-dev qt6-base-dev
-          pkg-config --modversion Qt6Core
+          if [ $RUNNER_OS = Linux ]; then
+            sudo apt-get update
+            sudo apt-get install -y g++ make nlohmann-json3-dev qt6-base-dev pkg-config libtinyxml2-dev
+          elif [ $RUNNER_OS = macOS ]; then
+            brew update
+            brew install qt pkg-config nlohmann-json tinyxml2
+          else
+            choco install -y mingw make pkgconfiglite qt6-base-dev tinyxml2
+          fi
 
       - name: Build core
-        run: make -C core
-
-      - name: Test
+        id: build_core
         run: |
+          set -o pipefail
+          make -C core 2>&1 | tee core_build.log
+        continue-on-error: true
+
+      - name: Build duke module
+        id: build_duke
+        run: |
+          set -o pipefail
+          make -C src/duke 2>&1 | tee duke_build.log
+        continue-on-error: true
+
+      - name: Run tests
+        id: run_tests
+        run: |
+          set -o pipefail
           export QT_QPA_PLATFORM=offscreen
-          make -C tests
+          make -C tests 2>&1 | tee tests.log
+        continue-on-error: true
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: logs-${{ matrix.os }}
+          path: |
+            core_build.log
+            duke_build.log
+            tests.log
+
+      - name: Fail if errors
+        if: steps.build_core.outcome == 'failure' || steps.build_duke.outcome == 'failure' || steps.run_tests.outcome == 'failure'
+        run: exit 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ERP DUKE
 
+[![CI](https://github.com/OWNER/calculator/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/calculator/actions/workflows/ci.yml)
+
 ERP DUKE é um sistema ERP modular voltado para o planejamento de cortes de materiais e gestão de projetos.
 
 ## Requisitos
@@ -51,6 +53,17 @@ make gui        # gera app_gui
 ```
 
 Certifique-se de que o Qt 6 esteja instalado e que `pkg-config` consiga encontrá-lo.
+
+## Testes
+
+O status das execuções automatizadas está disponível no badge de CI acima.
+
+Para rodar todos os testes localmente:
+
+```sh
+export QT_QPA_PLATFORM=offscreen
+make -C tests
+```
 
 ## Documentação
 


### PR DESCRIPTION
## Summary
- compile core and DUKE modules in CI across Linux, macOS and Windows
- cache build artifacts and upload logs if the job fails
- document CI badge and how to run tests locally

## Testing
- `make -C core`
- `make -C src/duke`
- `make -C tests` *(fails: command timed out after 180s)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e4e8a0588327a44b9c01b6da7fbe