### PR TITLE
Qualify MainWindow instantiation in Qt entry point

### DIFF
--- a/src/duke/gui/main_qt.cpp
+++ b/src/duke/gui/main_qt.cpp
@@ -9,7 +9,7 @@
 #ifndef UNIT_TEST
 int main(int argc, char* argv[]) {
     QApplication app(argc, argv);
-    MainWindow w;
+    duke::gui::MainWindow w;
     w.show();
     return app.exec();
 }


### PR DESCRIPTION
## Summary
- Use fully qualified duke::gui::MainWindow in Qt GUI entry point

## Testing
- `cd src/duke && make gui` *(fails: fatal error: QObject: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f674f6408327aa8d569da059efe9