### PR TITLE
Refatora criação de materiais padrão

### DIFF
--- a/include/duke/ApplicationCore.h
+++ b/include/duke/ApplicationCore.h
@@ -74,6 +74,7 @@ public:
     double somarLancamentos(const finance::Filtro& f) const;
 
 private:
+    std::vector<MaterialDTO> criarMateriaisPadrao() const;
     std::vector<MaterialDTO> base_;
     std::vector<Material> mats_;
     std::vector<Customer> clientes_;

--- a/src/duke/ApplicationCore.cpp
+++ b/src/duke/ApplicationCore.cpp
@@ -6,14 +6,18 @@
 
 namespace duke {
 
+std::vector<MaterialDTO> ApplicationCore::criarMateriaisPadrao() const {
+    return {
+        {"Pinus 20cm", 17.00, 0.20, 3.00, "linear"},
+        {"MDF 15mm", 180.00, 1.85, 2.75, "linear"}
+    };
+}
+
 bool ApplicationCore::carregar(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
     int schemaVersion = 0;
     if (!::Persist::load("materiais.json", base, &schemaVersion) || base.empty()) {
         wr::p("DATA", "Base nao encontrada. Criando materiais padrao...", "Yellow");
-        base = {
-            {"Pinus 20cm", 17.00, 0.20, 3.00, "linear"},
-            {"MDF 15mm", 180.00, 1.85, 2.75, "linear"}
-        };
+        base = criarMateriaisPadrao();
         if (::Persist::save("materiais.json", base, 1)) {
             wr::p("DATA", "materiais.json criado.", "Green");
         } else {
@@ -50,10 +54,7 @@ bool ApplicationCore::carregar() {
     int schemaVersion = 0;
     if (!::Persist::load("materiais.json", base_, &schemaVersion) || base_.empty()) {
         wr::p("DATA", "Base nao encontrada. Criando materiais padrao...", "Yellow");
-        base_ = {
-            {"Pinus 20cm", 17.00, 0.20, 3.00, "linear"},
-            {"MDF 15mm", 180.00, 1.85, 2.75, "linear"}
-        };
+        base_ = criarMateriaisPadrao();
         ::Persist::save("materiais.json", base_, 1);
     }
     mats_ = core::reconstruirMateriais(base_);

--- a/tests/duke/application_core_test.cpp
+++ b/tests/duke/application_core_test.cpp
@@ -9,15 +9,23 @@ void test_application_core() {
     std::filesystem::remove_all("tmp_appcore");
     Persist::Config cfg; cfg.baseDir = "tmp_appcore";
     Persist::setConfig(cfg);
+
+    ApplicationCore core;
+    std::vector<MaterialDTO> base;
+    std::vector<Material> mats;
+    // Carregamento padrão quando o arquivo não existe
+    assert(core.carregar(base, mats));
+    assert(base.size() == 2);
+    assert(base[0].nome == "Pinus 20cm");
+    assert(base[1].nome == "MDF 15mm");
+
     std::vector<MaterialDTO> itens = {
         {"Madeira", 100.0, 2.0, 3.0, "linear"},
         {"Aco", 200.0, 1.0, 4.0, "linear"}
     };
     Persist::save("materiais.json", itens);
-
-    ApplicationCore core;
-    std::vector<MaterialDTO> base;
-    std::vector<Material> mats;
+    base.clear();
+    mats.clear();
     assert(core.carregar(base, mats));
     auto lista = core.listarMateriais(base);
     assert(lista.size() == 2);
@@ -45,4 +53,17 @@ void test_application_core() {
     base.clear();
     mats.clear();
     assert(!core.carregar(base, mats));
+
+    // Verifica carregamento padrão via API de vendas
+    std::filesystem::remove_all("tmp_appcore2");
+    Persist::Config cfg2; cfg2.baseDir = "tmp_appcore2";
+    Persist::setConfig(cfg2);
+    ApplicationCore core2;
+    assert(core2.carregar());
+    auto estoque = core2.listarEstoque();
+    assert(estoque.size() == 2);
+    assert(estoque[0].nome == "Pinus 20cm");
+    assert(estoque[1].nome == "MDF 15mm");
+
+    Persist::setConfig({});
 }


### PR DESCRIPTION
## Resumo
- Extraiu criação de materiais padrão para `ApplicationCore::criarMateriaisPadrao`
- Substituiu blocos duplicados por chamadas ao novo método
- Expandiu testes para cobrir inicialização com materiais padrão via API geral e de vendas

## Testes
- `make duke` *(falha: fatal error: QObject: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fb781cf883278a6a70adbae72c93