### PR TITLE
Retornar referencias constantes nas listagens

### DIFF
--- a/apps/sales/SalesApp.cpp
+++ b/apps/sales/SalesApp.cpp
@@ -72,7 +72,7 @@ void SalesApp::handleListCustomers() const {
 }
 
 void SalesApp::handleInventory() const {
-    auto estoque = core_->listarEstoque();
+    const auto& estoque = core_->listarEstoque();
     for (const auto& m : estoque) {
         std::cout << "- " << m.nome << " (R$" << m.valor << ")\n";
     }

--- a/include/duke/ApplicationCore.h
+++ b/include/duke/ApplicationCore.h
@@ -24,10 +24,10 @@ public:
     //   bool ok = core.carregar(base, mats);
     bool carregar(std::vector<MaterialDTO>& base, std::vector<Material>& mats);
 
-    // Lista materiais disponíveis. O retorno é uma cópia dos dados para exibição.
+    // Lista materiais disponíveis. O retorno é uma referência constante para os dados.
     // Exemplo:
-    //   auto itens = core.listarMateriais(base);
-    std::vector<MaterialDTO> listarMateriais(const std::vector<MaterialDTO>& base) const;
+    //   const auto& itens = core.listarMateriais(base);
+    const std::vector<MaterialDTO>& listarMateriais(const std::vector<MaterialDTO>& base) const;
 
     // Resultado da comparação de materiais com destaque para menor e maior preço por m².
     // Compara materiais selecionados pelos índices (base 0).
@@ -55,7 +55,7 @@ public:
     std::vector<Order> listarPedidos() const;
 
     // Consulta o estoque de materiais carregado.
-    std::vector<MaterialDTO> listarEstoque() const;
+    const std::vector<MaterialDTO>& listarEstoque() const;
 
     // ----- APIs do módulo financeiro -----
     // Carrega lançamentos financeiros do repositório padrão.

--- a/src/duke/ApplicationCore.cpp
+++ b/src/duke/ApplicationCore.cpp
@@ -37,7 +37,7 @@ bool ApplicationCore::carregar(std::vector<MaterialDTO>& base, std::vector<Mater
     return true;
 }
 
-std::vector<MaterialDTO> ApplicationCore::listarMateriais(const std::vector<MaterialDTO>& base) const {
+const std::vector<MaterialDTO>& ApplicationCore::listarMateriais(const std::vector<MaterialDTO>& base) const {
     return base;
 }
 
@@ -84,7 +84,7 @@ std::vector<Customer> ApplicationCore::listarClientes() const { return clientes_
 
 std::vector<Order> ApplicationCore::listarPedidos() const { return pedidos_; }
 
-std::vector<MaterialDTO> ApplicationCore::listarEstoque() const { return base_; }
+const std::vector<MaterialDTO>& ApplicationCore::listarEstoque() const { return base_; }
 
 // ----- APIs do módulo financeiro -----
 bool ApplicationCore::carregarFinanceiro() { return finRepo_.load(); }

--- a/src/duke/cli/app.cpp
+++ b/src/duke/cli/app.cpp
@@ -75,7 +75,7 @@ void App::menuMateriais() {
         }
         switch (op) {
             case 1: {
-                auto itens = core.listarMateriais(base);
+                const auto& itens = core.listarMateriais(base);
                 std::cout << "\nMateriais cadastrados:\n";
                 if (itens.empty()) {
                     std::cout << "(vazio)\n";
@@ -159,7 +159,7 @@ void App::compararMateriais() {
     ui::renderBreadcrumb({ui::toString(ui::MenuState::Principal),
                            ui::toString(ui::MenuState::Comparar),
                            "Materiais"});
-    auto itens = core.listarMateriais(base);
+    const auto& itens = core.listarMateriais(base);
     std::cout << "\nMateriais cadastrados:\n";
     if (itens.empty()) {
         std::cout << "(vazio)\n";

--- a/src/duke/cli/utils.cpp
+++ b/src/duke/cli/utils.cpp
@@ -7,7 +7,7 @@ namespace duke::cli {
 
 void listarMateriais(const std::vector<MaterialDTO>& base) {
     ApplicationCore core;
-    auto itens = core.listarMateriais(base);
+    const auto& itens = core.listarMateriais(base);
     std::cout << "\nMateriais cadastrados:\n";
     if (itens.empty()) {
         std::cout << "(vazio)\n";

--- a/tests/duke/application_core_test.cpp
+++ b/tests/duke/application_core_test.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <filesystem>
 #include <stdexcept>
+#include <type_traits>
 #include "core/persist.h"
 
 void test_application_core() {
@@ -27,8 +28,13 @@ void test_application_core() {
     base.clear();
     mats.clear();
     assert(core.carregar(base, mats));
-    auto lista = core.listarMateriais(base);
+    static_assert(std::is_same_v<decltype(core.listarMateriais(base)), const std::vector<MaterialDTO>&>);
+    const auto& lista = core.listarMateriais(base);
+    assert(&lista == &base);
     assert(lista.size() == 2);
+    auto copiaLista = lista;
+    copiaLista[0].nome = "Alterado";
+    assert(lista[0].nome != copiaLista[0].nome);
     auto comps = core.compararMateriais(mats, {0, 1});
     assert(comps.size() == 2);
     bool menor = false, maior = false;
@@ -60,7 +66,12 @@ void test_application_core() {
     Persist::setConfig(cfg2);
     ApplicationCore core2;
     assert(core2.carregar());
-    auto estoque = core2.listarEstoque();
+    static_assert(std::is_same_v<decltype(core2.listarEstoque()), const std::vector<MaterialDTO>&>);
+    const auto& estoque = core2.listarEstoque();
+    auto backupNome = estoque[0].nome;
+    auto copiaEstoque = estoque;
+    copiaEstoque[0].nome = "Outro";
+    assert(estoque[0].nome == backupNome);
     assert(estoque.size() == 2);
     assert(estoque[0].nome == "Pinus 20cm");
     assert(estoque[1].nome == "MDF 15mm");

--- a/tests/sales/sales_core_test.cpp
+++ b/tests/sales/sales_core_test.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <vector>
 #include <cassert>
+#include <type_traits>
 
 // Testa criação de pedido
 void test_criar_pedido() {
@@ -48,7 +49,11 @@ void test_consulta_estoque() {
     Persist::save("materiais.json", mats);
 
     ApplicationCore core; core.carregar();
-    auto estoque = core.listarEstoque();
+    static_assert(std::is_same_v<decltype(core.listarEstoque()), const std::vector<MaterialDTO>&>);
+    const auto& estoque = core.listarEstoque();
+    auto copia = estoque;
+    copia[0].nome = "Mudado";
+    assert(estoque[0].nome != copia[0].nome);
     assert(estoque.size() == 1);
     assert(estoque[0].nome == "Estoque");
     std::filesystem::remove_all("tmp_sales_inv");


### PR DESCRIPTION
## Summary
- Alterar listarMateriais e listarEstoque para retornar `const std::vector<MaterialDTO>&`
- Atualizar chamadas para usar referências constantes
- Adicionar testes garantindo que alterações em cópias não modificam os vetores originais

## Testing
- `./build.sh` *(fails: fatal error: tinyxml2.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6079023248327b8a063c5ee112f5f