### PR TITLE
Validate sales order input

### DIFF
--- a/src/duke/ApplicationCore.cpp
+++ b/src/duke/ApplicationCore.cpp
@@ -69,6 +69,11 @@ bool ApplicationCore::carregar() {
 }
 
 bool ApplicationCore::criarPedido(const std::string& cliente, const std::string& item, int quantidade) {
+    if (cliente.empty() || item.empty() || quantidade <= 0) {
+        wr::p("SALES", "Dados de pedido invalidos", "Red");
+        return false;
+    }
+
     Order o(nextId_++, cliente, item, quantidade);
     pedidos_.push_back(o);
     bool ok = ::Persist::saveJSONVec("pedidos.json", pedidos_, "pedidos");

--- a/tests/sales/run_tests.cpp
+++ b/tests/sales/run_tests.cpp
@@ -3,11 +3,13 @@
 void test_criar_pedido();
 void test_listar_clientes();
 void test_consulta_estoque();
+void test_pedido_invalido();
 
 int main() {
     return run_tests({
         test_criar_pedido,
         test_listar_clientes,
-        test_consulta_estoque
+        test_consulta_estoque,
+        test_pedido_invalido
     });
 }

--- a/tests/sales/sales_core_test.cpp
+++ b/tests/sales/sales_core_test.cpp
@@ -58,3 +58,19 @@ void test_consulta_estoque() {
     assert(estoque[0].nome == "Estoque");
     std::filesystem::remove_all("tmp_sales_inv");
 }
+
+// Testa rejeição de entradas inválidas ao criar pedido
+void test_pedido_invalido() {
+    using namespace duke;
+    std::filesystem::remove_all("tmp_sales_bad");
+    Persist::Config cfg; cfg.baseDir = "tmp_sales_bad"; Persist::setConfig(cfg);
+    Persist::save("materiais.json", std::vector<MaterialDTO>{{"Prod", 1,1,1,"linear"}});
+    Persist::saveJSONVec("clientes.json", std::vector<Customer>{Customer{"Ana"}}, "clientes");
+
+    ApplicationCore core; core.carregar();
+    assert(!core.criarPedido("", "Prod", 1));
+    assert(!core.criarPedido("Ana", "", 1));
+    assert(!core.criarPedido("Ana", "Prod", 0));
+    assert(core.listarPedidos().empty());
+    std::filesystem::remove_all("tmp_sales_bad");
+}


### PR DESCRIPTION
## Summary
- reject sales orders with empty client, empty item or non-positive quantity
- add sales tests for invalid order inputs

## Testing
- `make -C tests sales`

------
https://chatgpt.com/codex/tasks/task_e_68a60ceb216c83278b0bca2a2e535c48