### PR TITLE
Enforce non-negative Material setters

### DIFF
--- a/include/duke/Material.h
+++ b/include/duke/Material.h
@@ -28,7 +28,7 @@ public:
 
     void setLarg(double l);
     void setComp(double c);
-    void setValor(double v);
+    void setValor(double novoValor);
 
     void mostrar() const;
 };

--- a/src/duke/Material.cpp
+++ b/src/duke/Material.cpp
@@ -1,6 +1,7 @@
 #include "Material.h"
 #include "core/format.h"
 #include <iostream>
+#include <stdexcept>
 namespace duke {
 
 void Material::iniciar() noexcept {
@@ -25,9 +26,23 @@ double Material::getLarg()  const noexcept { return largura; }
 double Material::getComp()  const noexcept { return comprimento; }
 double Material::getPorm2() const noexcept { return porm2; }
 
-void Material::setLarg(double l) { largura = l; iniciar(); }
-void Material::setComp(double c) { comprimento = c; iniciar(); }
-void Material::setValor(double v) { valor = v; iniciar(); }
+void Material::setLarg(double l) {
+    if (l < 0) throw std::invalid_argument("largura negativa");
+    largura = l;
+    iniciar();
+}
+
+void Material::setComp(double c) {
+    if (c < 0) throw std::invalid_argument("comprimento negativo");
+    comprimento = c;
+    iniciar();
+}
+
+void Material::setValor(double novoValor) {
+    if (novoValor < 0) throw std::invalid_argument("valor negativo");
+    valor = novoValor;
+    iniciar();
+}
 
 void Material::mostrar() const {
     std::cout << "Material      : " << getNome() << "\n"

--- a/tests/duke/material_validacao_tipo_test.cpp
+++ b/tests/duke/material_validacao_tipo_test.cpp
@@ -1,5 +1,7 @@
 #include "core/persist.h"
+#include "duke/Material.h"
 #include <cassert>
+#include <stdexcept>
 
 // Testa Persist::validar para tipos de material
 void testValidarMaterialPorTipo() {
@@ -14,4 +16,34 @@ void testValidarMaterialPorTipo() {
     // Tipo inválido
     MaterialDTO inv{"X", 1.0, 0.0, 0.0, "foo"};
     assert(Persist::validar(inv).code == ErrorCode::InvalidType);
+
+    // Setters devem lançar para valores negativos
+    Material m{"Mat", 10.0, 2.0, 3.0};
+
+    m.setValor(20.0);
+    assert(m.getValor() == 20.0);
+
+    bool errou = false;
+    try {
+        m.setValor(-1.0);
+    } catch (const std::invalid_argument&) {
+        errou = true;
+    }
+    assert(errou);
+
+    errou = false;
+    try {
+        m.setLarg(-1.0);
+    } catch (const std::invalid_argument&) {
+        errou = true;
+    }
+    assert(errou);
+
+    errou = false;
+    try {
+        m.setComp(-1.0);
+    } catch (const std::invalid_argument&) {
+        errou = true;
+    }
+    assert(errou);
 }


### PR DESCRIPTION
## Summary
- Throw `std::invalid_argument` in `Material` setters when negative values are provided
- Add tests covering setter validation

## Testing
- `make duke`


------
https://chatgpt.com/codex/tasks/task_e_68a6134313f08327aa3436ca2e7b4d52