### PR TITLE
Allow Material::mostrar to write to arbitrary streams

### DIFF
--- a/include/duke/Material.h
+++ b/include/duke/Material.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <iostream>
 namespace duke {
 
 class Material {
@@ -30,7 +31,7 @@ public:
     void setComp(double c);
     void setValor(double novoValor);
 
-    void mostrar() const;
+    void mostrar(std::ostream& out = std::cout) const;
 };
 
 } // namespace duke

--- a/src/duke/Material.cpp
+++ b/src/duke/Material.cpp
@@ -1,6 +1,5 @@
 #include "Material.h"
 #include "core/format.h"
-#include <iostream>
 #include <stdexcept>
 namespace duke {
 
@@ -44,11 +43,11 @@ void Material::setValor(double novoValor) {
     iniciar();
 }
 
-void Material::mostrar() const {
-    std::cout << "Material      : " << getNome() << "\n"
-              << "Area          : " << getArea() << UN_AREA << "\n"
-              << "Valor Total   : " << UN_MONE << getValor() << "\n"
-              << "Valor por m2  : " << UN_MONE << getPorm2() << "\n\n";
+void Material::mostrar(std::ostream& out) const {
+    out << "Material      : " << getNome() << "\n"
+        << "Area          : " << getArea() << UN_AREA << "\n"
+        << "Valor Total   : " << UN_MONE << getValor() << "\n"
+        << "Valor por m2  : " << UN_MONE << getPorm2() << "\n\n";
 }
 
 } // namespace duke

--- a/tests/duke/material_mostrar_test.cpp
+++ b/tests/duke/material_mostrar_test.cpp
@@ -1,0 +1,17 @@
+#include "duke/Material.h"
+#include "core/format.h"
+#include <cassert>
+#include <sstream>
+
+// Testa Material::mostrar escrevendo em um stream
+void test_material_mostrar() {
+    Material m{"Madeira", 10.0, 2.0, 3.0};
+    std::ostringstream oss;
+    m.mostrar(oss);
+    std::ostringstream expected;
+    expected << "Material      : " << m.getNome() << "\n"
+             << "Area          : " << m.getArea() << UN_AREA << "\n"
+             << "Valor Total   : " << UN_MONE << m.getValor() << "\n"
+             << "Valor por m2  : " << UN_MONE << m.getPorm2() << "\n\n";
+    assert(oss.str() == expected.str());
+}

--- a/tests/duke/run_tests.cpp
+++ b/tests/duke/run_tests.cpp
@@ -19,6 +19,7 @@ void test_data_path();
 void test_domain_material();
 void test_material_factory();
 void testValidarMaterialPorTipo();
+void test_material_mostrar();
 void test_estimador_custo();
 void test_projeto();
 void test_projeto_custo();
@@ -47,6 +48,7 @@ int main() {
         test_domain_material,
         test_material_factory,
         testValidarMaterialPorTipo,
+        test_material_mostrar,
         test_estimador_custo,
         test_projeto,
         test_projeto_custo,


### PR DESCRIPTION
## Summary
- let `Material::mostrar` write to a supplied `std::ostream`, defaulting to `std::cout`
- add unit test capturing `mostrar` output with `std::ostringstream`
- register new test in suite

## Testing
- `make -C tests duke` *(fails: fatal error: QObject: No such file or directory / Package Qt6Core not found)*
- `g++ -std=c++17 -Iinclude -Iinclude/duke -Icore/include -Ithird_party/nlohmann -Itests/duke -Itests -include tests/duke/namespace.h src/duke/Material.cpp tests/duke/material_mostrar_test.cpp /tmp/main.cpp -o /tmp/material_test && /tmp/material_test && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68a61acf18b0832793bb22e8278864d7