### PR TITLE
Validate material selection input tokens

### DIFF
--- a/src/duke/comparison.cpp
+++ b/src/duke/comparison.cpp
@@ -1,6 +1,9 @@
 #include "comparison.h"
+#include <algorithm>
+#include <cctype>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_set>
 #include "core.h"
 
 namespace duke::comparison {
@@ -25,9 +28,19 @@ Selecionados selecionarMateriais(const std::string& ids,
                                  const std::vector<Material>& mats) {
     std::istringstream iss(ids);
     std::vector<int> vecIds;
-    int id = 0;
-    while (iss >> id) {
-        vecIds.push_back(id - 1);
+    std::unordered_set<int> vistos;
+    std::string token;
+    while (iss >> token) {
+        if (token.empty() ||
+            !std::all_of(token.begin(), token.end(),
+                         [](unsigned char c) { return std::isdigit(c); })) {
+            throw std::invalid_argument("Token nao numerico");
+        }
+        int idx = std::stoi(token) - 1;
+        if (!vistos.insert(idx).second) {
+            throw std::invalid_argument("Indice duplicado");
+        }
+        vecIds.push_back(idx);
     }
     Selecionados sel;
     sel.materiais = selecionarMateriais(vecIds, mats);

--- a/tests/duke/comparison_test.cpp
+++ b/tests/duke/comparison_test.cpp
@@ -38,4 +38,22 @@ void test_comparison() {
         threw = true;
     }
     assert(threw);
+
+    // token nao numerico
+    threw = false;
+    try {
+        comparison::selecionarMateriais("1 a", mats);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    assert(threw);
+
+    // indice duplicado
+    threw = false;
+    try {
+        comparison::selecionarMateriais("1 1", mats);
+    } catch (const std::invalid_argument&) {
+        threw = true;
+    }
+    assert(threw);
 }


### PR DESCRIPTION
## Summary
- validate numeric tokens and duplicate indices when selecting materials
- add tests for invalid tokens and duplicate selections

## Testing
- `make -C tests` *(fails: fatal error: QObject: No such file or directory)*
- `make -C tests duke GUI_SRC=` *(fails: fatal error: tinyxml2.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6246b38848327b8f92c8a26466625