### PR TITLE
refactor: aplicar qualificacao explicita a namespace duke

### DIFF
--- a/src/duke/main.cpp
+++ b/src/duke/main.cpp
@@ -8,8 +8,6 @@
 #include "duke/duke.hpp"
 #include <string>
 
-using namespace duke;
-
 // ----------------------------------------------------------
 // Entrada principal da aplicação
 // Processa argumentos e executa o App
@@ -20,11 +18,11 @@ using namespace duke;
 #ifndef UNIT_TEST
 int main(int argc, char* argv[]) {
     // Interpreta opções da linha de comando
-    CliOptions opt = parseArgs(argc, argv);
+    duke::CliOptions opt = duke::parseArgs(argc, argv);
     if (!opt.errors.empty()) {
         return static_cast<int>(opt.errors.front().code);
     }
     // Processa comandos através da interface pública
-    return processarComando(opt);
+    return duke::processarComando(opt);
 }
 #endif // UNIT_TEST

--- a/tests/duke/application_core_test.cpp
+++ b/tests/duke/application_core_test.cpp
@@ -7,14 +7,13 @@
 #include <type_traits>
 
 void test_application_core() {
-    using namespace duke;
     std::filesystem::remove_all("tmp_appcore");
     Persist::Config cfg; cfg.baseDir = "tmp_appcore";
     Persist::setConfig(cfg);
 
-    ApplicationCore core;
+    duke::ApplicationCore core;
     std::vector<MaterialDTO> base;
-    std::vector<Material> mats;
+    std::vector<duke::Material> mats;
     // Carregamento padrão quando o arquivo não existe
     assert(core.carregar(base, mats));
     assert(base.size() == 2);
@@ -65,7 +64,7 @@ void test_application_core() {
     std::filesystem::remove_all("tmp_appcore2");
     Persist::Config cfg2; cfg2.baseDir = "tmp_appcore2";
     Persist::setConfig(cfg2);
-    ApplicationCore core2;
+    duke::ApplicationCore core2;
     assert(core2.carregar());
     static_assert(std::is_same_v<decltype(core2.listarEstoque()), const std::vector<MaterialDTO>&>);
     const auto& estoque = core2.listarEstoque();

--- a/tests/duke/comparison_test.cpp
+++ b/tests/duke/comparison_test.cpp
@@ -3,16 +3,15 @@
 #include "core.h"
 
 void test_comparison() {
-    using namespace duke;
     std::vector<MaterialDTO> base = {
         {"Madeira", 100.0, 2.0, 3.0, "linear"},
         {"Aco", 200.0, 1.0, 4.0, "linear"}
     };
-    auto mats = core::reconstruirMateriais(base);
+    auto mats = duke::core::reconstruirMateriais(base);
 
     // caso valido
-    auto sel = comparison::selecionarMateriais("1 2", mats);
-    auto comps = comparison::compararMateriais(sel.materiais);
+    auto sel = duke::comparison::selecionarMateriais("1 2", mats);
+    auto comps = duke::comparison::compararMateriais(sel.materiais);
     assert(comps.size() == 2);
     bool menor = false, maior = false;
     for (const auto& c : comps) {
@@ -24,7 +23,7 @@ void test_comparison() {
     // id invalido
     bool threw = false;
     try {
-        comparison::selecionarMateriais("1 3", mats);
+        duke::comparison::selecionarMateriais("1 3", mats);
     } catch (const std::out_of_range&) {
         threw = true;
     }
@@ -33,7 +32,7 @@ void test_comparison() {
     // ids insuficientes
     threw = false;
     try {
-        comparison::selecionarMateriais("1", mats);
+        duke::comparison::selecionarMateriais("1", mats);
     } catch (const std::invalid_argument&) {
         threw = true;
     }
@@ -42,7 +41,7 @@ void test_comparison() {
     // token nao numerico
     threw = false;
     try {
-        comparison::selecionarMateriais("1 a", mats);
+        duke::comparison::selecionarMateriais("1 a", mats);
     } catch (const std::invalid_argument&) {
         threw = true;
     }
@@ -51,7 +50,7 @@ void test_comparison() {
     // indice duplicado
     threw = false;
     try {
-        comparison::selecionarMateriais("1 1", mats);
+        duke::comparison::selecionarMateriais("1 1", mats);
     } catch (const std::invalid_argument&) {
         threw = true;
     }

--- a/tests/sales/sales_core_test.cpp
+++ b/tests/sales/sales_core_test.cpp
@@ -8,15 +8,14 @@
 
 // Testa criação de pedido
 void test_criar_pedido() {
-    using namespace duke;
     std::filesystem::remove_all("tmp_sales");
     Persist::Config cfg; cfg.baseDir = "tmp_sales"; Persist::setConfig(cfg);
     std::vector<MaterialDTO> mats{{"Prod", 10.0, 1.0, 1.0, "linear"}};
     Persist::save("materiais.json", mats);
-    std::vector<Customer> clientes{Customer{"Ana"}};
+    std::vector<duke::Customer> clientes{duke::Customer{"Ana"}};
     Persist::saveJSONVec("clientes.json", clientes, "clientes");
 
-    ApplicationCore core;
+    duke::ApplicationCore core;
     core.carregar();
     assert(core.criarPedido("Ana", "Prod", 1));
     auto pedidos = core.listarPedidos();
@@ -27,14 +26,13 @@ void test_criar_pedido() {
 
 // Testa listagem de clientes
 void test_listar_clientes() {
-    using namespace duke;
     std::filesystem::remove_all("tmp_sales_cli");
     Persist::Config cfg; cfg.baseDir = "tmp_sales_cli"; Persist::setConfig(cfg);
-    std::vector<Customer> clientes{Customer{"Bia"}, Customer{"Carlos"}};
+    std::vector<duke::Customer> clientes{duke::Customer{"Bia"}, duke::Customer{"Carlos"}};
     Persist::saveJSONVec("clientes.json", clientes, "clientes");
     Persist::save("materiais.json", std::vector<MaterialDTO>{{"X",1,1,1,"linear"}});
 
-    ApplicationCore core; core.carregar();
+    duke::ApplicationCore core; core.carregar();
     auto lista = core.listarClientes();
     assert(lista.size() == 2);
     assert(lista[0].nome == "Bia");
@@ -43,13 +41,12 @@ void test_listar_clientes() {
 
 // Testa consulta de estoque
 void test_consulta_estoque() {
-    using namespace duke;
     std::filesystem::remove_all("tmp_sales_inv");
     Persist::Config cfg; cfg.baseDir = "tmp_sales_inv"; Persist::setConfig(cfg);
     std::vector<MaterialDTO> mats{{"Estoque", 5.0, 1.0, 1.0, "linear"}};
     Persist::save("materiais.json", mats);
 
-    ApplicationCore core; core.carregar();
+    duke::ApplicationCore core; core.carregar();
     static_assert(std::is_same_v<decltype(core.listarEstoque()), const std::vector<MaterialDTO>&>);
     const auto& estoque = core.listarEstoque();
     auto copia = estoque;
@@ -62,13 +59,12 @@ void test_consulta_estoque() {
 
 // Testa rejeição de entradas inválidas ao criar pedido
 void test_pedido_invalido() {
-    using namespace duke;
     std::filesystem::remove_all("tmp_sales_bad");
     Persist::Config cfg; cfg.baseDir = "tmp_sales_bad"; Persist::setConfig(cfg);
     Persist::save("materiais.json", std::vector<MaterialDTO>{{"Prod", 1,1,1,"linear"}});
-    Persist::saveJSONVec("clientes.json", std::vector<Customer>{Customer{"Ana"}}, "clientes");
+    Persist::saveJSONVec("clientes.json", std::vector<duke::Customer>{duke::Customer{"Ana"}}, "clientes");
 
-    ApplicationCore core; core.carregar();
+    duke::ApplicationCore core; core.carregar();
     assert(!core.criarPedido("", "Prod", 1));
     assert(!core.criarPedido("Ana", "", 1));
     assert(!core.criarPedido("Ana", "Prod", 0));


### PR DESCRIPTION
## Summary
- remover diretivas globais e usar qualificadores `duke::` no ponto de entrada
- adaptar testes para usar `duke::` explicitamente, incluindo casos de comparação, core e vendas

## Testing
- `make duke`
- `make sales`


------
https://chatgpt.com/codex/tasks/task_e_68a6267c1c008327820ead850b53066a