### PR TITLE
feat: add dependency check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ O sistema depende da toolkit [Qt 6](https://www.qt.io/qt-6).
 Instale as bibliotecas de desenvolvimento e garanta que `pkg-config`
 as encontre antes de compilar.
 
+## Instalação
+
+Antes de compilar, verifique se as dependências básicas estão presentes.
+O script abaixo detecta o sistema e checa ferramentas como `g++`, `make`
+e bibliotecas do Qt 6, oferecendo a opção de instalá-las automaticamente:
+
+```sh
+./scripts/check_deps.sh
+```
+
+Execute-o sempre que configurar um novo ambiente de desenvolvimento.
+
 ## Compilação
 
 O projeto é dividido em módulos compilados separadamente.

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Detect distribution
+if command -v lsb_release >/dev/null 2>&1; then
+    distro=$(lsb_release -si)
+else
+    distro=$(uname -s)
+fi
+
+# Map dependencies to package names
+# key: check target (command or pkg-config name)
+# value: package name for package manager
+declare -A deps=(
+    ["g++"]="g++"
+    ["make"]="make"
+    ["pkg-config"]="pkg-config"
+    ["Qt6Core"]="qt6-base-dev"
+)
+
+missing=()
+packages=()
+
+for dep in "${!deps[@]}"; do
+    pkg="${deps[$dep]}"
+    if [[ "$dep" == Qt6Core ]]; then
+        if ! pkg-config --exists "$dep" 2>/dev/null; then
+            missing+=("$dep")
+            packages+=("$pkg")
+        fi
+    else
+        if ! command -v "$dep" >/dev/null 2>&1; then
+            missing+=("$dep")
+            packages+=("$pkg")
+        fi
+    fi
+done
+
+if [ ${#missing[@]} -eq 0 ]; then
+    echo "Todas as dependências estão instaladas."
+    exit 0
+fi
+
+echo "Dependências faltantes: ${missing[*]}"
+read -p "Instalar? [y/N] " reply
+if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+    echo "Instalação cancelada."
+    exit 1
+fi
+
+case "$distro" in
+    Ubuntu|Debian)
+        manager="sudo apt install -y"
+        ;;
+    Fedora|CentOS|RedHatEnterpriseServer)
+        manager="sudo dnf install -y"
+        ;;
+    Arch|ManjaroLinux)
+        manager="sudo pacman -S --noconfirm"
+        ;;
+    *)
+        echo "Distribuição $distro não suportada para instalação automática."
+        exit 2
+        ;;
+esac
+
+if $manager "${packages[@]}"; then
+    echo "Instalação concluída."
+else
+    echo "Falha na instalação."
+    exit 3
+fi


### PR DESCRIPTION
## Summary
- add `check_deps.sh` to verify and optionally install build requirements
- document dependency check usage in README

## Testing
- `./scripts/check_deps.sh <<'EOF'
N
EOF`
- `make -C tests` *(fails: fatal error: QObject: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6303e27708327b37774b0a01fe57d