### PR TITLE
Add Windows dependency check script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,26 @@ as encontre antes de compilar.
 ## Instalação
 
 Antes de compilar, verifique se as dependências básicas estão presentes.
-O script abaixo detecta o sistema e checa ferramentas como `g++`, `make`
-e bibliotecas do Qt 6, oferecendo a opção de instalá-las automaticamente:
+Para Linux e macOS, o script `check_deps.sh` detecta o sistema e checa
+ferramentas como `g++`, `make` e bibliotecas do Qt 6, oferecendo a opção de
+instalá-las automaticamente. No Windows há uma versão equivalente em
+PowerShell (`check_deps.ps1`) que usa `winget` ou `choco` para instalar
+pacotes faltantes.
+
+Linux/macOS:
 
 ```sh
 ./scripts/check_deps.sh
 ```
 
-Execute-o sempre que configurar um novo ambiente de desenvolvimento.
+Windows (PowerShell):
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\check_deps.ps1
+```
+
+Execute o script apropriado sempre que configurar um novo ambiente de
+desenvolvimento.
 
 ## Compilação
 

--- a/scripts/check_deps.ps1
+++ b/scripts/check_deps.ps1
@@ -1,0 +1,66 @@
+# PowerShell script to check and optionally install project dependencies
+# Similar to scripts/check_deps.sh but for Windows.
+
+$ErrorActionPreference = "Stop"
+
+# Map dependencies to package identifiers for winget and Chocolatey
+$deps = @{
+    "g++"       = @{winget="GNU.Mingw-w64"; choco="mingw"; cmd="g++"}
+    "make"      = @{winget="GnuWin32.Make"; choco="make"; cmd="make"}
+    "gdb"       = @{winget="GnuWin32.GDB";  choco="gdb";  cmd="gdb"}
+    "pkg-config"= @{winget="pkgconfiglite.pkgconfiglite"; choco="pkgconfiglite"; cmd="pkg-config"}
+    "Qt6Core"   = @{winget="Qt.Qt6";        choco="qt6-base"; cmd="pkg-config --exists Qt6Core"}
+}
+
+$missing = @()
+
+foreach ($name in $deps.Keys) {
+    $checkCmd = $deps[$name].cmd
+    if ($name -eq "Qt6Core") {
+        $p = Start-Process -FilePath pkg-config -ArgumentList "--exists", "Qt6Core" -NoNewWindow -PassThru -Wait -ErrorAction SilentlyContinue
+        if ($p.ExitCode -ne 0) { $missing += $name }
+    } else {
+        if (-not (Get-Command $checkCmd.Split()[0] -ErrorAction SilentlyContinue)) {
+            $missing += $name
+        }
+    }
+}
+
+if ($missing.Count -eq 0) {
+    Write-Host "Todas as dependências estão instaladas."
+    exit 0
+}
+
+Write-Host "Dependências faltantes: $($missing -join ', ')"
+$reply = Read-Host "Instalar? [y/N]"
+if ($reply -notmatch '^[Yy]$') {
+    Write-Host "Instalação cancelada."
+    exit 1
+}
+
+if (Get-Command winget -ErrorAction SilentlyContinue) {
+    foreach ($dep in $missing) {
+        $pkg = $deps[$dep].winget
+        if ($pkg) {
+            Write-Host "Instalando $pkg via winget..."
+            winget install --id $pkg -e --silent --accept-package-agreements --accept-source-agreements
+        } else {
+            Write-Host "Sem mapeamento winget para $dep"
+        }
+    }
+} elseif (Get-Command choco -ErrorAction SilentlyContinue) {
+    foreach ($dep in $missing) {
+        $pkg = $deps[$dep].choco
+        if ($pkg) {
+            Write-Host "Instalando $pkg via choco..."
+            choco install $pkg -y
+        } else {
+            Write-Host "Sem mapeamento choco para $dep"
+        }
+    }
+} else {
+    Write-Host "Nenhum gerenciador de pacotes suportado encontrado (winget ou choco)."
+    exit 2
+}
+
+Write-Host "Verificação concluída."


### PR DESCRIPTION
## Summary
- add `check_deps.ps1` to verify/install dependencies on Windows via winget or Chocolatey
- document Windows dependency script in README

## Testing
- `./scripts/check_deps.sh` (fails: Dependências faltantes: Qt6Core)
- `make -C tests` (fails: fatal error: QObject: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a5f7e848708327b2406bf91c05e653