### PR TITLE
Switch build system to wxWidgets

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1,9 +1,9 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -Wall -fPIC
 INCLUDES = -Iinclude -I../include -I../third_party/nlohmann
-QT_CFLAGS := $(shell pkg-config --cflags Qt6Core)
-QT_LIBS := $(shell pkg-config --libs Qt6Core)
-CXXFLAGS += $(QT_CFLAGS)
+WX_CXXFLAGS := $(shell wx-config --cxxflags)
+WX_LIBS := $(shell wx-config --libs)
+CXXFLAGS += $(WX_CXXFLAGS)
 XML_LIBS := $(shell pkg-config --libs tinyxml2 2>/dev/null || echo -ltinyxml2)
 
 SRC = $(wildcard src/*.cpp)
@@ -15,7 +15,7 @@ libcore.a: $(OBJ)
 	ar rcs $@ $(OBJ)
 
 libcore.so: $(OBJ)
-	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(QT_LIBS) $(XML_LIBS) -o $@
+	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(WX_LIBS) $(XML_LIBS) -o $@
 
 %.o: src/%.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@

--- a/scripts/check_deps.ps1
+++ b/scripts/check_deps.ps1
@@ -9,20 +9,15 @@ $deps = @{
     "make"      = @{winget="GnuWin32.Make"; choco="make"; cmd="make"}
     "gdb"       = @{winget="GnuWin32.GDB";  choco="gdb";  cmd="gdb"}
     "pkg-config"= @{winget="pkgconfiglite.pkgconfiglite"; choco="pkgconfiglite"; cmd="pkg-config"}
-    "Qt6Core"   = @{winget="Qt.Qt6";        choco="qt6-base"; cmd="pkg-config --exists Qt6Core"}
+    "wxWidgets" = @{winget="wxWidgets.wxWidgets"; choco="wxwidgets"; cmd="wx-config"}
 }
 
 $missing = @()
 
 foreach ($name in $deps.Keys) {
     $checkCmd = $deps[$name].cmd
-    if ($name -eq "Qt6Core") {
-        $p = Start-Process -FilePath pkg-config -ArgumentList "--exists", "Qt6Core" -NoNewWindow -PassThru -Wait -ErrorAction SilentlyContinue
-        if ($p.ExitCode -ne 0) { $missing += $name }
-    } else {
-        if (-not (Get-Command $checkCmd.Split()[0] -ErrorAction SilentlyContinue)) {
-            $missing += $name
-        }
+    if (-not (Get-Command $checkCmd.Split()[0] -ErrorAction SilentlyContinue)) {
+        $missing += $name
     }
 }
 

--- a/scripts/check_deps.sh
+++ b/scripts/check_deps.sh
@@ -16,7 +16,7 @@ declare -A deps=(
     ["g++"]="g++"
     ["make"]="make"
     ["pkg-config"]="pkg-config"
-    ["Qt6Core"]="qt6-base-dev"
+    ["wx-config"]="libwxgtk3.2-dev"
 )
 
 missing=()
@@ -24,16 +24,9 @@ packages=()
 
 for dep in "${!deps[@]}"; do
     pkg="${deps[$dep]}"
-    if [[ "$dep" == Qt6Core ]]; then
-        if ! pkg-config --exists "$dep" 2>/dev/null; then
-            missing+=("$dep")
-            packages+=("$pkg")
-        fi
-    else
-        if ! command -v "$dep" >/dev/null 2>&1; then
-            missing+=("$dep")
-            packages+=("$pkg")
-        fi
+    if ! command -v "$dep" >/dev/null 2>&1; then
+        missing+=("$dep")
+        packages+=("$pkg")
     fi
 done
 

--- a/src/duke/Makefile
+++ b/src/duke/Makefile
@@ -2,9 +2,9 @@ CXX = g++
 CXXFLAGS = -std=c++17 -Wall -fPIC
 CORE_DIR = ../../core
 INCLUDES = -I../../include -I../../include/duke -I../../third_party/nlohmann -I$(CORE_DIR)/include
-QT_CFLAGS := $(shell pkg-config --cflags Qt6Widgets 2>/dev/null)
-QT_LIBS := $(shell pkg-config --libs Qt6Widgets 2>/dev/null)
-CXXFLAGS += $(QT_CFLAGS)
+WX_CXXFLAGS := $(shell wx-config --cxxflags)
+WX_LIBS := $(shell wx-config --libs)
+CXXFLAGS += $(WX_CXXFLAGS)
 
 CORE_LIB = $(CORE_DIR)/libcore.a
 
@@ -27,17 +27,17 @@ libduke.a: $(OBJ) $(CORE_LIB)
 	ar rcs $@ $(OBJ)
 
 libduke.so: $(OBJ) $(CORE_LIB)
-	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(QT_LIBS) -L$(CORE_DIR) -lcore -o $@
+	$(CXX) $(CXXFLAGS) -shared $(OBJ) $(WX_LIBS) -L$(CORE_DIR) -lcore -o $@
 
 %.o: %.cpp
 	@mkdir -p $(dir $@)
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c $< -o $@
 
 cli: libduke.a $(CORE_LIB) main.cpp
-	$(CXX) $(CXXFLAGS) main.cpp $(INCLUDES) -L. -lduke -L$(CORE_DIR) -lcore $(QT_LIBS) -o app
+	$(CXX) $(CXXFLAGS) main.cpp $(INCLUDES) -L. -lduke -L$(CORE_DIR) -lcore $(WX_LIBS) -o app
 
 gui: libduke.a $(CORE_LIB) $(GUI_OBJ) $(GUI_MAIN_OBJ)
-	        $(CXX) $(CXXFLAGS) $(GUI_OBJ) $(GUI_MAIN_OBJ) $(INCLUDES) -L. -lduke -L$(CORE_DIR) -lcore $(QT_LIBS) -o app_gui
+	$(CXX) $(CXXFLAGS) $(GUI_OBJ) $(GUI_MAIN_OBJ) $(INCLUDES) -L. -lduke -L$(CORE_DIR) -lcore $(WX_LIBS) -o app_gui
 
 .PHONY: clean cli gui
 clean:


### PR DESCRIPTION
## Summary
- switch core and DUKE modules from Qt6 build flags to wx-config supplied flags
- check wxWidgets in dependency scripts for Linux and Windows
- ensure Makefile recipes use proper tab prefixes

## Testing
- `./scripts/check_deps.sh` (fails: Dependências faltantes: wx-config)
- `make -C tests` (fails: make[1]: wx-config: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a647659a8083278322ffd837ca19c3