### PR TITLE
Replace Qt remnants with wxWidgets event handlers

### DIFF
--- a/include/duke/gui/GuiBridge.h
+++ b/include/duke/gui/GuiBridge.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <vector>
-#include <QObject>
 #include "ApplicationCore.h"
 #include "Material.h"
 #include "core.h"
@@ -17,19 +16,14 @@ namespace gui {
 //   GuiBridge b(core, base, mats);
 //   b.selecionarMaterial(0);
 // ==========================================
-class GuiBridge : public QObject {
-    Q_OBJECT
-
+class GuiBridge {
 public:
     GuiBridge(ApplicationCore& core,
               const std::vector<MaterialDTO>& base,
-              const std::vector<Material>& mats,
-              QObject* parent = nullptr);
+              const std::vector<Material>& mats);
 
-public slots:
     void selecionarMaterial(int idx);
 
-public:
     int ultimaSelecao() const { return m_last; }
 
 private:

--- a/include/duke/gui/MainWindow.h
+++ b/include/duke/gui/MainWindow.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <wx/frame.h>
+#include <wx/event.h>
 #include <vector>
 #include <utility>
 
@@ -10,6 +11,7 @@ class wxButton;
 class wxTextCtrl;
 class wxMenuBar;
 class wxMenu;
+class wxCommandEvent;
 
 #include "gui/GuiBridge.h"
 
@@ -34,6 +36,12 @@ public:
     ~MainWindow() override = default;
 
 private:
+    // Handlers de eventos
+    void OnSearchFieldText(wxCommandEvent& evt);
+    void OnSelectButton(wxCommandEvent& evt);
+
+    wxDECLARE_EVENT_TABLE();
+
     gui::GuiBridge* m_bridge;
     wxPanel* m_centralPanel;
     wxBoxSizer* m_layout;

--- a/src/duke/gui/GuiBridge.cpp
+++ b/src/duke/gui/GuiBridge.cpp
@@ -7,9 +7,8 @@ namespace gui {
 
 GuiBridge::GuiBridge(ApplicationCore& core,
                      const std::vector<MaterialDTO>& base,
-                     const std::vector<Material>& mats,
-                     QObject* parent)
-    : QObject{parent}, m_core(core), m_base(base), m_mats(mats), m_last{-1} {}
+                     const std::vector<Material>& mats)
+    : m_core(core), m_base(base), m_mats(mats), m_last{-1} {}
 
 void GuiBridge::selecionarMaterial(int idx) {
     wr::p("GUI", "Selecionando material " + std::to_string(idx), "Blue");

--- a/src/duke/gui/MainWindow.cpp
+++ b/src/duke/gui/MainWindow.cpp
@@ -7,6 +7,11 @@
 namespace duke {
 namespace gui {
 
+wxBEGIN_EVENT_TABLE(MainWindow, wxFrame)
+    EVT_TEXT(wxID_ANY, MainWindow::OnSearchFieldText)
+    EVT_BUTTON(wxID_ANY, MainWindow::OnSelectButton)
+wxEND_EVENT_TABLE()
+
 // Construtor: inicializa widgets e conecta eventos.
 MainWindow::MainWindow(gui::GuiBridge* bridge,
                        wxPanel* centralPanel,
@@ -63,31 +68,30 @@ MainWindow::MainWindow(gui::GuiBridge* bridge,
         m_menuBar->Append(menu, m.first);
         m_menus.push_back({menu, m.first});
     }
+}
 
-    // filtro de busca para o menu
-    m_searchField->Bind(wxEVT_TEXT, [this](wxCommandEvent& evt) {
-        wxString txt = evt.GetString();
-        if (txt.IsEmpty()) {
-            m_searchField->SetBackgroundColour(*wxRED);
-        } else {
-            m_searchField->SetBackgroundColour(wxNullColour);
+void MainWindow::OnSearchFieldText(wxCommandEvent& evt) {
+    wxString txt = evt.GetString();
+    if (txt.IsEmpty()) {
+        m_searchField->SetBackgroundColour(*wxRED);
+    } else {
+        m_searchField->SetBackgroundColour(wxNullColour);
+    }
+    m_searchField->Refresh();
+    for (auto& pair : m_menus) {
+        int pos = m_menuBar->FindMenu(pair.second);
+        if (pos != wxNOT_FOUND) {
+            bool vis = pair.second.Lower().Find(txt.Lower()) != wxNOT_FOUND;
+            m_menuBar->EnableTop(pos, vis);
         }
-        m_searchField->Refresh();
-        for (auto& pair : m_menus) {
-            int pos = m_menuBar->FindMenu(pair.second);
-            if (pos != wxNOT_FOUND) {
-                bool vis = pair.second.Lower().Find(txt.Lower()) != wxNOT_FOUND;
-                m_menuBar->EnableTop(pos, vis);
-            }
-        }
-    });
+    }
+}
 
-    // conecta clique do botão à ponte de seleção
-    m_selectButton->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
-        if (m_bridge) {
-            m_bridge->selecionarMaterial(0);
-        }
-    });
+void MainWindow::OnSelectButton(wxCommandEvent& evt) {
+    (void)evt;
+    if (m_bridge) {
+        m_bridge->selecionarMaterial(0);
+    }
 }
 
 } // namespace gui


### PR DESCRIPTION
## Summary
- Remove Qt dependencies from GuiBridge and rely on plain C++ class
- Hook button click and text change via wxWidgets event table in MainWindow
- Convert lambda callbacks into explicit wxCommandEvent handlers

## Testing
- `make -C tests` *(fails: undefined reference to finance::FinanceRepo::load)*

------
https://chatgpt.com/codex/tasks/task_e_68a64dcf820083278f60950aebd143fa