### PR TITLE
Fix test targets linking

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -55,9 +55,9 @@ ifeq ($(strip $(PROD_SRCS)),)
 	@echo "No production tests"
 else
 	@mkdir -p production
-	$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) \
-	-Iproduction -I.. -I../include -I../include/duke -I../core/include \
-	$(LIB_CORE) $(XML_LIBS) \
+	$(CXX) $(CXXFLAGS) $(PROD_SRCS) $(PROD_APP_SRCS) $(FIN_LIB_SRCS) \
+	-Iproduction -I.. -I../include -I../include/duke -I../core/include -I../third_party/nlohmann \
+	$(LIB_CALC) $(LIB_CORE) $(XML_LIBS) \
 	-o production/run_tests
 	./production/run_tests
 endif
@@ -87,7 +87,7 @@ designer:
 ifeq ($(strip $(DES_SRCS)),)
 	@echo "No designer tests"
 else
-	$(CXX) $(CXXFLAGS) $(DES_SRCS) ../apps/designer/DesignerApp.cpp $(PROD_LIB_SRCS) \
+	$(CXX) $(CXXFLAGS) $(DES_SRCS) ../apps/designer/DesignerApp.cpp $(PROD_LIB_SRCS) $(FIN_LIB_SRCS) \
 	-I../apps/designer -I../include -I../include/duke -I../third_party/nlohmann -I../core/include $(LIB_CORE) $(XML_LIBS) -o designer/run_tests
 	./designer/run_tests
 endif


### PR DESCRIPTION
## Summary
- include finance sources when building designer tests
- add finance and duke libraries and json include to production test target

## Testing
- `make -C tests`

------
https://chatgpt.com/codex/tasks/task_e_68a65562e41c8327b42ec64e9384158c