### PR TITLE
fix app include paths

### DIFF
--- a/apps/admin/CMakeLists.txt
+++ b/apps/admin/CMakeLists.txt
@@ -5,9 +5,9 @@ project(duke_admin_app)
 add_executable(duke_admin main.cpp AdminApp.cpp)
 
 target_include_directories(duke_admin PRIVATE
-    ${CMAKE_SOURCE_DIR}/core/include
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/finance/include
+    ${PROJECT_SOURCE_DIR}/../../core/include
+    ${PROJECT_SOURCE_DIR}/../../include
+    ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
 target_link_libraries(duke_admin PRIVATE core duke finance)

--- a/apps/designer/CMakeLists.txt
+++ b/apps/designer/CMakeLists.txt
@@ -5,14 +5,14 @@ project(duke_designer_app)
 add_executable(duke_designer
     main.cpp
     DesignerApp.cpp
-    ${CMAKE_SOURCE_DIR}/src/production/ModeloProducao.cpp
+    ${PROJECT_SOURCE_DIR}/../../src/production/ModeloProducao.cpp
 )
 
 target_include_directories(duke_designer PRIVATE
-    ${CMAKE_SOURCE_DIR}/core/include
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/finance/include
-    ${CMAKE_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/../../core/include
+    ${PROJECT_SOURCE_DIR}/../../include
+    ${PROJECT_SOURCE_DIR}/../../finance/include
+    ${PROJECT_SOURCE_DIR}/../../include
 )
 
 target_link_libraries(duke_designer PRIVATE core duke finance)

--- a/apps/production/CMakeLists.txt
+++ b/apps/production/CMakeLists.txt
@@ -5,9 +5,9 @@ project(duke_production_app)
 add_executable(duke_production main.cpp ProductionApp.cpp)
 
 target_include_directories(duke_production PRIVATE
-    ${CMAKE_SOURCE_DIR}/core/include
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/finance/include
+    ${PROJECT_SOURCE_DIR}/../../core/include
+    ${PROJECT_SOURCE_DIR}/../../include
+    ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
 target_link_libraries(duke_production PRIVATE core duke finance)

--- a/apps/sales/CMakeLists.txt
+++ b/apps/sales/CMakeLists.txt
@@ -9,9 +9,9 @@ project(duke_sales_app)
 add_executable(duke_sales main.cpp SalesApp.cpp)
 
 target_include_directories(duke_sales PRIVATE
-    ${CMAKE_SOURCE_DIR}/core/include
-    ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/finance/include
+    ${PROJECT_SOURCE_DIR}/../../core/include
+    ${PROJECT_SOURCE_DIR}/../../include
+    ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
 target_link_libraries(duke_sales PRIVATE core duke finance)


### PR DESCRIPTION
## Summary
- use `PROJECT_SOURCE_DIR` to reference repository root in each app's CMakeLists
- update designer app to reference production source via `PROJECT_SOURCE_DIR`

## Testing
- `cmake -S apps/admin -B build/admin`
- `cmake --build build/admin` *(fails: cannot find -lcore -lduke -lfinance)*
- `cmake -S apps/designer -B build/designer`
- `cmake --build build/designer` *(fails: nlohmann/json.hpp: No such file or directory)*
- `cmake -S apps/production -B build/production`
- `cmake --build build/production` *(fails: nlohmann/json.hpp: No such file or directory)*
- `cmake -S apps/sales -B build/sales`
- `cmake --build build/sales` *(fails: nlohmann/json.hpp: No such file or directory)*
- `make -C tests` *(fails: wx-config: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6710941b08327a1e4c5961e2c500a