### PR TITLE
Add modular CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(calculator)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+add_subdirectory(core)
+add_subdirectory(src/duke)
+add_subdirectory(src/finance)
+
+add_subdirectory(apps/admin)
+add_subdirectory(apps/designer)
+add_subdirectory(apps/production)
+add_subdirectory(apps/sales)

--- a/apps/admin/CMakeLists.txt
+++ b/apps/admin/CMakeLists.txt
@@ -10,5 +10,5 @@ target_include_directories(duke_admin PRIVATE
     ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
-target_link_libraries(duke_admin PRIVATE core duke finance)
+target_link_libraries(duke_admin PRIVATE core_lib duke_lib finance_lib)
 

--- a/apps/designer/CMakeLists.txt
+++ b/apps/designer/CMakeLists.txt
@@ -15,5 +15,5 @@ target_include_directories(duke_designer PRIVATE
     ${PROJECT_SOURCE_DIR}/../../include
 )
 
-target_link_libraries(duke_designer PRIVATE core duke finance)
+target_link_libraries(duke_designer PRIVATE core_lib duke_lib finance_lib)
 

--- a/apps/production/CMakeLists.txt
+++ b/apps/production/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(duke_production_app)
 
-add_executable(duke_production main.cpp ProductionApp.cpp)
+add_executable(duke_production
+    main.cpp
+    ProductionApp.cpp
+    ${PROJECT_SOURCE_DIR}/../../src/production/ModeloProducao.cpp
+)
 
 target_include_directories(duke_production PRIVATE
     ${PROJECT_SOURCE_DIR}/../../core/include
@@ -10,5 +14,5 @@ target_include_directories(duke_production PRIVATE
     ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
-target_link_libraries(duke_production PRIVATE core duke finance)
+target_link_libraries(duke_production PRIVATE core_lib duke_lib finance_lib)
 

--- a/apps/sales/CMakeLists.txt
+++ b/apps/sales/CMakeLists.txt
@@ -14,5 +14,5 @@ target_include_directories(duke_sales PRIVATE
     ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
-target_link_libraries(duke_sales PRIVATE core duke finance)
+target_link_libraries(duke_sales PRIVATE core_lib duke_lib finance_lib)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,0 +1,20 @@
+add_library(core_lib
+    src/atomic_write.cpp
+    src/core.cpp
+    src/notifications.cpp
+    src/paths.cpp
+    src/persist.cpp
+    src/persist_csv.cpp
+    src/persist_json.cpp
+    src/persist_xml.cpp
+    src/reports.cpp
+    src/settings.cpp
+    ${CMAKE_SOURCE_DIR}/third_party/tinyxml2/tinyxml2.cpp
+)
+
+target_include_directories(core_lib PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/third_party/nlohmann
+    ${CMAKE_SOURCE_DIR}/third_party/tinyxml2
+)

--- a/src/duke/CMakeLists.txt
+++ b/src/duke/CMakeLists.txt
@@ -1,0 +1,15 @@
+file(GLOB_RECURSE DUKE_SOURCES CONFIGURE_DEPENDS *.cpp)
+list(REMOVE_ITEM DUKE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
+list(REMOVE_ITEM DUKE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/gui/MainWindow.cpp)
+list(REMOVE_ITEM DUKE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/gui/main_wx.cpp)
+
+add_library(duke_lib ${DUKE_SOURCES})
+
+target_include_directories(duke_lib PUBLIC
+    ${CMAKE_SOURCE_DIR}/include/duke
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/core/include
+    ${CMAKE_SOURCE_DIR}/third_party/nlohmann
+)
+
+target_link_libraries(duke_lib PUBLIC core_lib)

--- a/src/finance/CMakeLists.txt
+++ b/src/finance/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_library(finance_lib
+    Repo.cpp
+    Report.cpp
+    Serialize.cpp
+    SupplierRepo.cpp
+)
+
+target_include_directories(finance_lib PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/core/include
+    ${CMAKE_SOURCE_DIR}/third_party/nlohmann
+)
+
+target_link_libraries(finance_lib PUBLIC core_lib)


### PR DESCRIPTION
## Summary
- add top-level CMake project wiring core, duke and finance libraries
- provide individual CMakeLists for core, duke and finance modules
- link apps against the new libraries and include production model source

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build || true`


------
https://chatgpt.com/codex/tasks/task_e_68a672f68a9083279bd07b005710401d