### PR TITLE
Configure C++17 standard project-wide

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ project(calculator)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_subdirectory(core)
 add_subdirectory(src/duke)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -4,6 +4,10 @@ cmake_minimum_required(VERSION 3.10)
 
 project(duke_apps)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Add subdirectories for each app.  Each app will be built into its own
 # executable.  These directories contain their own CMakeLists that link
 # against the core libraries.


### PR DESCRIPTION
## Summary
- Enforce C++17 and disable compiler extensions for all builds
- Apply the same C++17 settings to the apps build configuration so subprojects inherit

## Testing
- `make -C tests` *(fails: wx-config not found and linker errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a675385ba88327b1e99efe7b11085b