### PR TITLE
Create production library and clean designer includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_subdirectory(core)
 add_subdirectory(src/duke)
 add_subdirectory(src/finance)
+add_subdirectory(src/production)
 
 add_subdirectory(apps/admin)
 add_subdirectory(apps/designer)

--- a/apps/designer/CMakeLists.txt
+++ b/apps/designer/CMakeLists.txt
@@ -5,15 +5,13 @@ project(duke_designer_app)
 add_executable(duke_designer
     main.cpp
     DesignerApp.cpp
-    ${PROJECT_SOURCE_DIR}/../../src/production/ModeloProducao.cpp
 )
 
 target_include_directories(duke_designer PRIVATE
     ${PROJECT_SOURCE_DIR}/../../core/include
     ${PROJECT_SOURCE_DIR}/../../include
     ${PROJECT_SOURCE_DIR}/../../finance/include
-    ${PROJECT_SOURCE_DIR}/../../include
 )
 
-target_link_libraries(duke_designer PRIVATE core_lib duke_lib finance_lib)
+target_link_libraries(duke_designer PRIVATE core_lib duke_lib finance_lib production)
 

--- a/src/production/CMakeLists.txt
+++ b/src/production/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(production
+    ModeloProducao.cpp
+)
+
+target_include_directories(production PUBLIC
+    ${CMAKE_SOURCE_DIR}/include
+)


### PR DESCRIPTION
## Summary
- add standalone `production` library and expose its headers
- link `duke_designer` against `production` instead of compiling sources directly
- remove duplicate include entry in designer build

## Testing
- `cmake -S . -B build`
- `cmake --build build --target duke_designer`
- `./build.sh` *(fails: undefined references and wx widgets build issues)*

------
https://chatgpt.com/codex/tasks/task_e_68a6777faedc8327957060d619a7fb55