### PR TITLE
Atualizar caminhos de include nas apps

### DIFF
--- a/apps/admin/CMakeLists.txt
+++ b/apps/admin/CMakeLists.txt
@@ -7,7 +7,6 @@ add_executable(duke_admin main.cpp AdminApp.cpp)
 target_include_directories(duke_admin PRIVATE
     ${PROJECT_SOURCE_DIR}/../../core/include
     ${PROJECT_SOURCE_DIR}/../../include
-    ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
 target_link_libraries(duke_admin PRIVATE core_lib duke_lib finance_lib)

--- a/apps/designer/CMakeLists.txt
+++ b/apps/designer/CMakeLists.txt
@@ -10,7 +10,6 @@ add_executable(duke_designer
 target_include_directories(duke_designer PRIVATE
     ${PROJECT_SOURCE_DIR}/../../core/include
     ${PROJECT_SOURCE_DIR}/../../include
-    ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
 target_link_libraries(duke_designer PRIVATE core_lib duke_lib finance_lib production)

--- a/apps/production/CMakeLists.txt
+++ b/apps/production/CMakeLists.txt
@@ -11,7 +11,6 @@ add_executable(duke_production
 target_include_directories(duke_production PRIVATE
     ${PROJECT_SOURCE_DIR}/../../core/include
     ${PROJECT_SOURCE_DIR}/../../include
-    ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
 target_link_libraries(duke_production PRIVATE core_lib duke_lib finance_lib)

--- a/apps/sales/CMakeLists.txt
+++ b/apps/sales/CMakeLists.txt
@@ -11,7 +11,6 @@ add_executable(duke_sales main.cpp SalesApp.cpp)
 target_include_directories(duke_sales PRIVATE
     ${PROJECT_SOURCE_DIR}/../../core/include
     ${PROJECT_SOURCE_DIR}/../../include
-    ${PROJECT_SOURCE_DIR}/../../finance/include
 )
 
 target_link_libraries(duke_sales PRIVATE core_lib duke_lib finance_lib)


### PR DESCRIPTION
## Summary
- atualizar CMakeLists das apps para apontar para `../../include`

## Testing
- `./build.sh` *(falhou: collect2: error: ld returned 1 exit status)*

------
https://chatgpt.com/codex/tasks/task_e_68a67d9e3a808327b9007660cd64f3c6