### PR TITLE
feat(cli): centralize material index selection

### DIFF
--- a/include/duke/cli/utils.h
+++ b/include/duke/cli/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <vector>
+#include <string>
 #include "core.h"
 #include "persist.hpp"
 
@@ -10,6 +11,11 @@ namespace duke::cli {
 // Exemplo:
 //   duke::cli::listarMateriais(base);
 void listarMateriais(const std::vector<MaterialDTO>& base);
+
+// Lê um índice de material válido (1..n) e retorna a posição (0..n-1)
+// Exemplo:
+//   size_t idx = duke::cli::readMaterialIndex(base, "Indice: ");
+size_t readMaterialIndex(const std::vector<MaterialDTO>& base, const std::string& prompt);
 
 // Reconstrói vetor de Materiais e persiste base
 // Exemplo:

--- a/src/duke/cli/commands.cpp
+++ b/src/duke/cli/commands.cpp
@@ -32,16 +32,8 @@ void adicionarMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& ma
 void editarMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
     if (base.empty()) return;
     listarMateriais(base);
-    size_t idx = 0;
-    while (true) {
-        int input = ui::readInt("Indice para editar: ");
-        if (input >= 1 && static_cast<size_t>(input) <= base.size()) {
-            idx = static_cast<size_t>(input);
-            break;
-        }
-        std::cout << "Indice invalido.\n";
-    }
-    MaterialDTO& m = base[idx - 1];
+    size_t idx = readMaterialIndex(base, "Indice para editar: ");
+    MaterialDTO& m = base[idx];
     std::string nome;
     std::cout << "Nome (" << m.nome << "): ";
     std::getline(std::cin, nome);
@@ -55,16 +47,8 @@ void editarMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats)
 void removerMaterial(std::vector<MaterialDTO>& base, std::vector<Material>& mats) {
     if (base.empty()) return;
     listarMateriais(base);
-    size_t idx = 0;
-    while (true) {
-        int input = ui::readInt("Indice para remover: ");
-        if (input >= 1 && static_cast<size_t>(input) <= base.size()) {
-            idx = static_cast<size_t>(input);
-            break;
-        }
-        std::cout << "Indice invalido.\n";
-    }
-    base.erase(base.begin() + static_cast<long>(idx - 1));
+    size_t idx = readMaterialIndex(base, "Indice para remover: ");
+    base.erase(base.begin() + static_cast<long>(idx));
     salvarReconstruir(base, mats);
 }
 

--- a/src/duke/cli/utils.cpp
+++ b/src/duke/cli/utils.cpp
@@ -2,8 +2,22 @@
 #include "cli/utils.h"
 #include "core/format.h"
 #include "ApplicationCore.h"
+#include "ui/Menu.h"
 
 namespace duke::cli {
+
+size_t readMaterialIndex(const std::vector<MaterialDTO>& base, const std::string& prompt) {
+    size_t idx = 0;
+    while (true) {
+        int input = ui::readInt(prompt);
+        if (input >= 1 && static_cast<size_t>(input) <= base.size()) {
+            idx = static_cast<size_t>(input - 1);
+            break;
+        }
+        std::cout << "Indice invalido.\n";
+    }
+    return idx;
+}
 
 void listarMateriais(const std::vector<MaterialDTO>& base) {
     ApplicationCore core;


### PR DESCRIPTION
## Summary
- add readMaterialIndex helper for CLI material selection
- refactor edit/remove commands to use new helper

## Testing
- `./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a78ef9446483278843216b8beaf79a